### PR TITLE
113 Overwrite or ignore if property/element already exists

### DIFF
--- a/src/Config.Parser/Parser.cs
+++ b/src/Config.Parser/Parser.cs
@@ -4,142 +4,146 @@ using Newtonsoft.Json.Linq;
 using pote.Config.DataProvider.Interfaces;
 using pote.Config.Shared;
 
-namespace pote.Config.Parser
+namespace pote.Config.Parser;
+
+public class Parser : IParser
 {
-    public class Parser : IParser
+    private readonly IDataProvider _dataProvider;
+
+    private const string RefPattern = "\\$ref:(?<ref>[^#]*)#(?<field>[^\"]*)";
+    //private const string NamePattern = "(?<name>[^.]*).?(?<application>[^.]*).?(?<environment>[^.]*)";
+
+    /// <summary>Add your own value to gather tracking data</summary>
+    public Action<string, string> TrackingAction { get; set; } = (_, _) => { };
+
+    public Parser(IDataProvider dataProvider)
     {
-        private readonly IDataProvider _dataProvider;
+        _dataProvider = dataProvider;
+    }
 
-        private const string RefPattern = "\\$ref:(?<ref>[^#]*)#(?<field>[^\"]*)";
-        //private const string NamePattern = "(?<name>[^.]*).?(?<application>[^.]*).?(?<environment>[^.]*)";
-
-        /// <summary>Add your own value to gather tracking data</summary>
-        public Action<string, string> TrackingAction { get; set; } = (_, _) => { };
-
-        public Parser(IDataProvider dataProvider)
+    /// <summary>Parses the specified configuration. Will do some pre- and post-processing.</summary>
+    public async Task<string> Parse(string json, string application, string environment, Action<string> problems,
+        CancellationToken cancellationToken, string rootId)
+    {
+        // Pre process
+        if (string.IsNullOrWhiteSpace(json))
         {
-            _dataProvider = dataProvider;
+            problems("Input json is empty.");
+            return "";
         }
 
-        /// <summary>Parses the specified configuration. Will do some pre- and post-processing.</summary>
-        public async Task<string> Parse(string json, string application, string environment, Action<string> problems,
-            CancellationToken cancellationToken, string rootId)
+        var root = JObject.Parse(json);
+        var applications = await _dataProvider.GetApplications(cancellationToken);
+        var dbApplication = applications.FirstOrDefault(s =>
+            s.Id == application || s.Name.Equals(application, StringComparison.InvariantCultureIgnoreCase));
+        if (dbApplication == null)
         {
-            // Pre process
-            if (string.IsNullOrWhiteSpace(json))
-            {
-                problems("Input json is empty.");
-                return "";
-            }
-
-            var root = JObject.Parse(json);
-            var applications = await _dataProvider.GetApplications(cancellationToken);
-            var dbApplication = applications.FirstOrDefault(s =>
-                s.Id == application || s.Name.Equals(application, StringComparison.InvariantCultureIgnoreCase));
-            if (dbApplication == null)
-            {
-                problems($"Application {application} not found");
-                return "";
-            }
-
-            var environments = await _dataProvider.GetEnvironments(cancellationToken);
-            var dbEnvironment = environments.FirstOrDefault(e =>
-                e.Id == environment || e.Name.Equals(environment, StringComparison.InvariantCultureIgnoreCase));
-            if (dbEnvironment == null)
-            {
-                problems($"Environment {environment} not found");
-                return "";
-            }
-
-            // Process
-            await HandleToken(root, dbApplication.Id, dbEnvironment.Id, problems, cancellationToken, rootId, new List<KeyValuePair<string, string>>());
-
-            // Post process
-            MoveBaseChildrenToRoot(root);
-            root.AddFirst(new JProperty("generated_timestamp_utc", DateTime.UtcNow.ToString("s")));
-            return root.ToString();
+            problems($"Application {application} not found");
+            return "";
         }
 
-        /// <summary>Method for recursively handling the tokens in the json</summary>
-        /// <param name="sourceConfigurationId">Used to track what's happening.</param>
-        [SuppressMessage("ReSharper", "InvalidXmlDocComment")]
-        private async Task HandleToken(JToken token, string application, string environment, Action<string> problems, CancellationToken cancellationToken, string sourceConfigurationId, List<KeyValuePair<string, string>> fetchedConfigurations)
+        var environments = await _dataProvider.GetEnvironments(cancellationToken);
+        var dbEnvironment = environments.FirstOrDefault(e =>
+            e.Id == environment || e.Name.Equals(environment, StringComparison.InvariantCultureIgnoreCase));
+        if (dbEnvironment == null)
         {
-            while (true)
+            problems($"Environment {environment} not found");
+            return "";
+        }
+
+        // Process
+        await HandleToken(root, dbApplication.Id, dbEnvironment.Id, problems, cancellationToken, rootId, new List<KeyValuePair<string, string>>());
+
+        // Post process
+        MoveBaseChildrenToRoot(root);
+        root.AddFirst(new JProperty("generated_timestamp_utc", DateTime.UtcNow.ToString("s")));
+        return root.ToString();
+    }
+
+    /// <summary>Method for recursively handling the tokens in the json</summary>
+    /// <param name="sourceConfigurationId">Used to track what's happening.</param>
+    [SuppressMessage("ReSharper", "InvalidXmlDocComment")]
+    private async Task HandleToken(JToken token, string application, string environment, Action<string> problems, CancellationToken cancellationToken, string sourceConfigurationId, List<KeyValuePair<string, string>> fetchedConfigurations)
+    {
+        while (true)
+        {
+            // Recurse into children
+            if (token.HasValues)
+                foreach (var child in token.Children())
+                    await HandleToken(child, application, environment, problems, cancellationToken, sourceConfigurationId, fetchedConfigurations);
+
+            // Check token for different types
+            if (token.Type != JTokenType.Property) return;
+            var jProp = token.Value<JProperty>();
+            if (jProp == null || jProp.Value.Type != JTokenType.String) return;
+            var value = jProp.Value.Value<string>();
+            if (value == null) return;
+
+            // Check if the value is a reference
+            var match = Regex.Match(value, RefPattern);
+            if (!match.Success) return;
+
+            // A match is found, now get the value from the database.
+            var configurationName = match.Groups[1].Value;
+            if (fetchedConfigurations.Any(pair => pair.Key.Equals(configurationName) && pair.Value.Equals(value)))
             {
-                // Recurse into children
-                if (token.HasValues)
-                    foreach (var child in token.Children())
-                        await HandleToken(child, application, environment, problems, cancellationToken, sourceConfigurationId, fetchedConfigurations);
+                problems($"Referenced configuration {configurationName} was already resolved from source configuration {sourceConfigurationId} and reference {value}.");
+                return;
+            }
+            var configuration = await _dataProvider.GetConfiguration(configurationName, application, environment, cancellationToken);
+            fetchedConfigurations.Add(new KeyValuePair<string, string>(configurationName, value));
+            if (string.IsNullOrWhiteSpace(configuration.Json))
+            {
+                problems($"Reference could not be resolved, {match.Groups[0].Value}");
+                return;
+            }
 
-                // Check token for different types
-                if (token.Type != JTokenType.Property) return;
-                var jProp = token.Value<JProperty>();
-                if (jProp == null || jProp.Value.Type != JTokenType.String) return;
-                var value = jProp.Value.Value<string>();
-                if (value == null) return;
+            var refO = JObject.Parse(configuration.Json);
+            var refField = match.Groups["field"];
+            var refToken = refO.SelectToken(refField.Value);
+            if (refToken == null) return;
 
-                // Check if the value is a reference
-                var match = Regex.Match(value, RefPattern);
-                if (!match.Success) return;
+            // Replace the value with the value from the database.
+            jProp.Value = refToken;
 
-                // A match is found, now get the value from the database.
-                var configurationName = match.Groups[1].Value;
-                if (fetchedConfigurations.Any(pair => pair.Key.Equals(configurationName) && pair.Value.Equals(value)))
-                {
-                    problems($"Referenced configuration {configurationName} was already resolved from source configuration {sourceConfigurationId} and reference {value}.");
-                    return;
-                }
-                var configuration = await _dataProvider.GetConfiguration(configurationName, application, environment, cancellationToken);
-                fetchedConfigurations.Add(new KeyValuePair<string, string>(configurationName, value));
-                if (string.IsNullOrWhiteSpace(configuration.Json))
-                {
-                    problems($"Reference could not be resolved, {match.Groups[0].Value}");
-                    return;
-                }
+            TrackingAction(sourceConfigurationId, configuration.HeaderId);
+            sourceConfigurationId = configuration.HeaderId;
 
-                var refO = JObject.Parse(configuration.Json);
-                var refField = match.Groups["field"];
-                var refToken = refO.SelectToken(refField.Value);
-                if (refToken == null) return;
-
-                // Replace the value with the value from the database.
-                jProp.Value = refToken;
-
-                TrackingAction(sourceConfigurationId, configuration.HeaderId);
-                sourceConfigurationId = configuration.HeaderId;
-
-                if (string.IsNullOrEmpty(refField.Value) && refToken.HasValues)
-                {
-                    // The field has no value, so it might have some children that we can work with. Overwrite token to the current JObject and continue. This is like a recursive call.
-                    token = refO;
-                }
+            if (string.IsNullOrEmpty(refField.Value) && refToken.HasValues)
+            {
+                // The field has no value, so it might have some children that we can work with. Overwrite token to the current JObject and continue. This is like a recursive call.
+                token = refO;
             }
         }
+    }
 
-        /// <summary>If a child of the root object is named 'Base' or 'base', it's child object are moved to the root. This comes into play when the input JSON needs to be completely replaced by the content of a configuration (not just the value but also the name).</summary>
-        /// <example>
-        /// Before:
-        /// {
-        ///    "Base": {
-        ///        "Spacecraft": {
-        ///            "Name": "Far Far Away"
-        ///        }
-        ///    }
-        /// }
-        /// After:
-        /// {
-        ///    "Spacecraft": {
-        ///        "Name": "Far Far Away"
-        ///    }
-        /// }
-        /// </example>
-        private static void MoveBaseChildrenToRoot(JObject root)
+    /// <summary>If a child of the root object is named 'Base' or 'base', it's child object are moved to the root. This comes into play when the input JSON needs to be completely replaced by the content of a configuration (not just the value but also the name). In case of name clash of elements in root, the existing element will be overwritten; Data from the configuration service wins.</summary>
+    /// <example>
+    /// Before:
+    /// {
+    ///    "Base": {
+    ///        "Spacecraft": {
+    ///            "Name": "Far Far Away"
+    ///        }
+    ///    }
+    /// }
+    /// After:
+    /// {
+    ///    "Spacecraft": {
+    ///        "Name": "Far Far Away"
+    ///    }
+    /// }
+    /// </example>
+    private static void MoveBaseChildrenToRoot(JObject root)
+    {
+        var baseObj = root.Property("Base") ?? root.Property("base");
+        if (baseObj == null) return;
+        foreach (var child in baseObj.Value.Children<JProperty>())
         {
-            var baseObj = root.Property("Base") ?? root.Property("base");
-            if (baseObj == null) return;
-            root.Add(baseObj.Value.Children<JProperty>());
-            baseObj.Remove();
+            var existing = root.Property(child.Name);
+            existing?.Remove();
+            root[child.Name] = child.Value;
         }
+        baseObj.Remove();
     }
 }

--- a/src/Config.UnitTests/ParserTests.cs
+++ b/src/Config.UnitTests/ParserTests.cs
@@ -45,6 +45,18 @@ public class ParserTests
         var dataProvider = new TestDataProvider();
         var parser = new Parser.Parser(dataProvider);
         var response = await parser.Parse("{\"Wagga\":\"$ref:Circular#\"}", "unittest", "test", _ => { }, CancellationToken.None, "");
-        var dyn = JsonConvert.DeserializeObject<dynamic>(response);
+        var _ = JsonConvert.DeserializeObject<dynamic>(response);
+    }
+
+    [Test]
+    public async Task SectionAlreadyInInput_Should_Overwrite()
+    {
+        var dataProvider = new TestDataProvider();
+        var parser = new Parser.Parser(dataProvider);
+        var response = await parser.Parse("{\"Base\":\"$ref:ExistingSection#\",\"Wagga\":\"Mama\",\"Foo\":{\"Baa\":true}}", "unittest", "test", _ => { }, CancellationToken.None, "");
+        var obj = JsonConvert.DeserializeObject<dynamic>(response);
+        Assert.AreEqual("TheRealMama", obj?.Wagga.ToString());
+        Assert.IsTrue(bool.TryParse(obj?.Foo.Baa.ToString(), out bool baa));
+        Assert.AreEqual(false, baa);
     }
 }

--- a/src/Config.UnitTests/TestDataProvider.cs
+++ b/src/Config.UnitTests/TestDataProvider.cs
@@ -12,25 +12,26 @@ public class TestDataProvider : IAdminDataProvider
     {
         return name switch
         {
-            "Wagga" => Task.FromResult(new Configuration { Json = "{\"Wagga\":\"Mama\"}" }),
-            "Wagga_nested" => Task.FromResult(new Configuration { Json = "{\"Wagga\":\"$ref:Super#\"}" }),
-            "Super" => Task.FromResult(new Configuration { Json = "{\"Super\":\"mule\",\"Super2\":\"mule2\"}" }),
-            "Circular" => Task.FromResult(new Configuration { Id = "0dfa086a-da82-4ed4-916c-a604aed33fbf", Json = "{\"Wagga\":\"$ref:RefCircular#\"}" }),
-            "RefCircular" => Task.FromResult(new Configuration { Id = "2b338c20-709e-4c56-a823-47fbdad051a8", Json = "{\"Dingo\":\"$ref:Circular#\"}" }),
-            "MultiRef" => Task.FromResult(new Configuration { Json = "{\"Wagga\":\"$ref:Wagga#\",\"Super\":\"$ref:Super#Super\",\"Super\":\"$ref:Super#Super2\"}", Applications = new List<string> { "AppId1" }, Environments = new List<string> { "EnvId1" } }),
+            "Wagga" => Task.FromResult(new Configuration {Json = "{\"Wagga\":\"Mama\"}"}),
+            "Wagga_nested" => Task.FromResult(new Configuration {Json = "{\"Wagga\":\"$ref:Super#\"}"}),
+            "Super" => Task.FromResult(new Configuration {Json = "{\"Super\":\"mule\",\"Super2\":\"mule2\"}"}),
+            "Circular" => Task.FromResult(new Configuration {Id = "0dfa086a-da82-4ed4-916c-a604aed33fbf", Json = "{\"Wagga\":\"$ref:RefCircular#\"}"}),
+            "RefCircular" => Task.FromResult(new Configuration {Id = "2b338c20-709e-4c56-a823-47fbdad051a8", Json = "{\"Dingo\":\"$ref:Circular#\"}"}),
+            "MultiRef" => Task.FromResult(new Configuration {Json = "{\"Wagga\":\"$ref:Wagga#\",\"Super\":\"$ref:Super#Super\",\"Super\":\"$ref:Super#Super2\"}", Applications = new List<string> {"AppId1"}, Environments = new List<string> {"EnvId1"}}),
+            "ExistingSection" => Task.FromResult(new Configuration {Json = "{\"Wagga\":\"TheRealMama\",\"Foo\":{\"Baa\":false}}" }),
             _ => Task.FromResult(new Configuration())
         };
     }
 
     public Task<List<Environment>> GetEnvironments(CancellationToken cancellationToken)
     {
-        var list = new List<Environment> { new() { Id = "EnvId1", Name = "test" } };
+        var list = new List<Environment> {new() {Id = "EnvId1", Name = "test"}};
         return Task.FromResult(list);
     }
 
     public Task<List<Application>> GetApplications(CancellationToken cancellationToken)
     {
-        var list = new List<Application> { new() { Id = "AppId1", Name = "unittest" } };
+        var list = new List<Application> {new() {Id = "AppId1", Name = "unittest"}};
         return Task.FromResult(list);
     }
 
@@ -45,11 +46,12 @@ public class TestDataProvider : IAdminDataProvider
         {
             "HeaderId1" => Task.FromResult(new ConfigurationHeader
             {
-                Id = id, Configurations = new List<Configuration> { GetConfiguration("MultiRef", "", "", CancellationToken.None).Result }
+                Id = id, Configurations = new List<Configuration> {GetConfiguration("MultiRef", "", "", CancellationToken.None).Result}
             }),
             _ => Task.FromResult(new ConfigurationHeader())
         });
     }
+
     public async Task<List<ConfigurationHeader>> GetHeaderHistory(string id, int page, int pageSize, CancellationToken cancellationToken)
     {
         throw new System.NotImplementedException();


### PR DESCRIPTION
https://github.com/poteb/ConfigurationService/issues/113

Overwrite element in root in case of name clash.
When "base" naming convention is used and elements are pushed to root, existing elements are replaced with elements from the configuration service.
