### PR TITLE
191 Add a cache for parsed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,5 @@ MigrationBackup/
 .idea/
 
 src/Config.Middleware/Config.Middleware.TestApi/appsettings.Development.Parsed.json
+
+src/.claude/worktrees/

--- a/src/Config.Middleware/Config.Middleware.Net/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.Net/ExtensionMethods.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using pote.Config.Shared;
@@ -16,22 +19,69 @@ public static class ExtensionMethods
             if (response == null)  throw new InvalidDataException("Reponse from API was empty.");
             var json = response.GetJson();
             await File.WriteAllTextAsync(parsedJsonFile, json);
+            await SaveToPersistentCacheAsync(configuration, json, errorOutput);
             return builder.AddJsonFile(parsedJsonFile, false, false);
         }
         catch (Exception ex)
         {
             errorOutput("Error getting configuration from API. Loading previously parsed configuration.", ex);
-            return builder.AddPreviouslyParsedConfiguration(parsedJsonFile);
+            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput);
         }
     }
-    
-    private static IConfigurationBuilder AddPreviouslyParsedConfiguration(this IConfigurationBuilder builder, string file)
+
+    private static IConfigurationBuilder AddFallbackConfiguration(this IConfigurationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput)
     {
-        if (!File.Exists(file))
-            throw new FileNotFoundException($"An old parsed configuration not found, file: {file}");
-        return builder.AddJsonFile(file, false, true);
+        if (File.Exists(parsedJsonFile))
+            return builder.AddJsonFile(parsedJsonFile, false, true);
+
+        var persistentFile = GetPersistentCachePath(configuration);
+        if (persistentFile != null && File.Exists(persistentFile))
+        {
+            errorOutput?.Invoke($"Local parsed configuration not found. Loading from persistent cache: {persistentFile}", null!);
+            return builder.AddJsonFile(persistentFile, false, true);
+        }
+
+        throw new FileNotFoundException(
+            $"No configuration found. Tried:{Environment.NewLine}" +
+            $"  1. Config service API at {configuration.RootApiUri}{Environment.NewLine}" +
+            $"  2. Local file: {parsedJsonFile}{Environment.NewLine}" +
+            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}");
     }
-    
+
+    private static async Task SaveToPersistentCacheAsync(BuilderConfiguration configuration, string json, Action<string, Exception> errorOutput)
+    {
+        try
+        {
+            var persistentFile = GetPersistentCachePath(configuration);
+            if (persistentFile == null) return;
+
+            var dir = Path.GetDirectoryName(persistentFile)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            await File.WriteAllTextAsync(persistentFile, json);
+        }
+        catch (Exception ex)
+        {
+            errorOutput?.Invoke("Failed to save persistent configuration cache. This is non-fatal.", ex);
+        }
+    }
+
+    private static string? GetPersistentCachePath(BuilderConfiguration configuration)
+    {
+        if (!configuration.EnablePersistentCache) return null;
+
+        var app = SanitizeDirectoryName(configuration.Application);
+        var env = SanitizeDirectoryName(configuration.Environment);
+        return Path.Combine(configuration.PersistentCacheBaseDirectory, app, env, $"appsettings.{env}.Parsed.json");
+    }
+
+    private static string SanitizeDirectoryName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(name.Where(c => !invalid.Contains(c)).ToArray()).ToLowerInvariant();
+    }
+
     /// <summary>Adds the BuilderConfiguration to the DI container.</summary>
     /// <param name="services">The IServiceCollection to add the BuilderConfiguration to.</param>
     /// <param name="application">The name of the application that is being configured.</param>

--- a/src/Config.Middleware/Config.Middleware.NetStandard/BuilderConfiguration.cs
+++ b/src/Config.Middleware/Config.Middleware.NetStandard/BuilderConfiguration.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace pote.Config.Middleware;
 
 public class BuilderConfiguration
@@ -6,4 +8,19 @@ public class BuilderConfiguration
     public string Application { get; set; } = "";
     public string Environment { get; set; } = "";
     public string WorkingDirectory { get; set; } = "";
+
+    /// <summary>
+    /// Enable persistent configuration cache that survives deployments.
+    /// When enabled, resolved configuration is also saved outside the deployment directory.
+    /// </summary>
+    public bool EnablePersistentCache { get; set; } = true;
+
+    /// <summary>
+    /// Base directory for persistent cache.
+    /// Default: C:\ProgramData\pote\ConfigurationCache
+    /// </summary>
+    public string PersistentCacheBaseDirectory { get; set; } =
+        Path.Combine(System.Environment.GetFolderPath(
+            System.Environment.SpecialFolder.CommonApplicationData),
+            "pote", "ConfigurationCache");
 }

--- a/src/Config.Middleware/Config.Middleware.NetStandard/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.NetStandard/ExtensionMethods.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using pote.Config.Shared;
 
@@ -15,21 +18,66 @@ public static class ExtensionMethods
             if (response == null)  throw new InvalidDataException("Reponse from API was empty.");
             var json = response.GetJson();
             File.WriteAllText(parsedJsonFile, json);
+            SaveToPersistentCache(configuration, json, errorOutput);
             return builder.AddJsonFile(parsedJsonFile, false, false);
         }
         catch (Exception ex)
         {
             errorOutput("Error getting configuration from API. Loading previously parsed configuration.", ex);
-            return builder.AddPreviouslyParsedConfiguration(parsedJsonFile);
+            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput);
         }
     }
-    
-    private static IConfigurationBuilder AddPreviouslyParsedConfiguration(this IConfigurationBuilder builder, string file)
+
+    private static IConfigurationBuilder AddFallbackConfiguration(this IConfigurationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput)
     {
-        if (!File.Exists(file))
-            throw new FileNotFoundException($"An old parsed configuration not found, file: {file}");
-        return builder.AddJsonFile(file, false, true);
+        if (File.Exists(parsedJsonFile))
+            return builder.AddJsonFile(parsedJsonFile, false, true);
+
+        var persistentFile = GetPersistentCachePath(configuration);
+        if (persistentFile != null && File.Exists(persistentFile))
+        {
+            errorOutput?.Invoke($"Local parsed configuration not found. Loading from persistent cache: {persistentFile}", null!);
+            return builder.AddJsonFile(persistentFile, false, true);
+        }
+
+        throw new FileNotFoundException(
+            $"No configuration found. Tried:{System.Environment.NewLine}" +
+            $"  1. Config service API at {configuration.RootApiUri}{System.Environment.NewLine}" +
+            $"  2. Local file: {parsedJsonFile}{System.Environment.NewLine}" +
+            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}");
     }
-    
-    
+
+    private static void SaveToPersistentCache(BuilderConfiguration configuration, string json, Action<string, Exception> errorOutput)
+    {
+        try
+        {
+            var persistentFile = GetPersistentCachePath(configuration);
+            if (persistentFile == null) return;
+
+            var dir = Path.GetDirectoryName(persistentFile)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            File.WriteAllText(persistentFile, json);
+        }
+        catch (Exception ex)
+        {
+            errorOutput?.Invoke("Failed to save persistent configuration cache. This is non-fatal.", ex);
+        }
+    }
+
+    private static string? GetPersistentCachePath(BuilderConfiguration configuration)
+    {
+        if (!configuration.EnablePersistentCache) return null;
+
+        var app = SanitizeDirectoryName(configuration.Application);
+        var env = SanitizeDirectoryName(configuration.Environment);
+        return Path.Combine(configuration.PersistentCacheBaseDirectory, app, env, $"appsettings.{env}.Parsed.json");
+    }
+
+    private static string SanitizeDirectoryName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(name.Where(c => !invalid.Contains(c)).ToArray()).ToLowerInvariant();
+    }
 }

--- a/src/Config.Middleware/Config.Middleware.Web.Net/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.Web.Net/ExtensionMethods.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,32 +30,74 @@ public static class ExtensionMethods
             if (response == null)  throw new InvalidDataException("Response from API was empty.");
             var json = response.GetJson();
             await File.WriteAllTextAsync(parsedJsonFile, json);
+            await SaveToPersistentCacheAsync(configuration, json, errorOutput);
             builder.Configuration.AddJsonFile(parsedJsonFile, false, false);
             return builder;
         }
         catch (Exception ex)
         {
             errorOutput("Error getting configuration from API. Loading previously parsed configuration.", ex);
-            return builder.AddPreviouslyParsedConfiguration(parsedJsonFile);
+            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput);
         }
     }
-    
-    // /// <summary>
-    // /// Reads the options from appsettings, adds the SecretResolver to the options and adds the options to the DI container.
-    // /// </summary>
-    // /// <param name="services">The IServiceCollection to add the options to.</param>
-    // /// <param name="configuration">The IConfiguration to read the options from.</param>
-    // /// <param name="secretResolver">The SecretResolver that was created in AddSecretsResolver.</param>
-    // /// <typeparam name="T">The options type that are being read from appsettings.</typeparam>
-    // /// <returns>Returns the options so that they can be used in during startup.</returns>
-    // public static T AddSecretConfiguration<T>(this IServiceCollection services, IConfiguration configuration, ISecretResolver secretResolver) where T : class, ISecretSettings
-    // {
-    //     var settings = configuration.GetSection(typeof (T).Name).Get<T>()!;
-    //     settings.SecretResolver = secretResolver;
-    //     services.AddSingleton<T>(_ => settings);
-    //     return settings;
-    // }
-    
+
+    private static WebApplicationBuilder AddFallbackConfiguration(this WebApplicationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput)
+    {
+        if (File.Exists(parsedJsonFile))
+        {
+            builder.Configuration.AddJsonFile(parsedJsonFile, false, true);
+            return builder;
+        }
+
+        var persistentFile = GetPersistentCachePath(configuration);
+        if (persistentFile != null && File.Exists(persistentFile))
+        {
+            errorOutput?.Invoke($"Local parsed configuration not found. Loading from persistent cache: {persistentFile}", null!);
+            builder.Configuration.AddJsonFile(persistentFile, false, true);
+            return builder;
+        }
+
+        throw new FileNotFoundException(
+            $"No configuration found. Tried:{Environment.NewLine}" +
+            $"  1. Config service API at {configuration.RootApiUri}{Environment.NewLine}" +
+            $"  2. Local file: {parsedJsonFile}{Environment.NewLine}" +
+            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}");
+    }
+
+    private static async Task SaveToPersistentCacheAsync(BuilderConfiguration configuration, string json, Action<string, Exception> errorOutput)
+    {
+        try
+        {
+            var persistentFile = GetPersistentCachePath(configuration);
+            if (persistentFile == null) return;
+
+            var dir = Path.GetDirectoryName(persistentFile)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            await File.WriteAllTextAsync(persistentFile, json);
+        }
+        catch (Exception ex)
+        {
+            errorOutput?.Invoke("Failed to save persistent configuration cache. This is non-fatal.", ex);
+        }
+    }
+
+    private static string? GetPersistentCachePath(BuilderConfiguration configuration)
+    {
+        if (!configuration.EnablePersistentCache) return null;
+
+        var app = SanitizeDirectoryName(configuration.Application);
+        var env = SanitizeDirectoryName(configuration.Environment);
+        return Path.Combine(configuration.PersistentCacheBaseDirectory, app, env, $"appsettings.{env}.Parsed.json");
+    }
+
+    private static string SanitizeDirectoryName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(name.Where(c => !invalid.Contains(c)).ToArray()).ToLowerInvariant();
+    }
+
     /// <summary>Adds the BuilderConfiguration to the DI container.</summary>
     /// <param name="services">The IServiceCollection to add the BuilderConfiguration to.</param>
     /// <param name="application">The name of the application that is being configured.</param>
@@ -72,28 +117,11 @@ public static class ExtensionMethods
         services.AddSingleton(configSettings);
         return configSettings;
     }
-    
+
     private static HttpClient CreateHttpClient(string apiKey)
     {
         var client = new HttpClient();
         client.DefaultRequestHeaders.Add("X-API-Key", apiKey);
         return client;
-    }
-    
-    
-    /// <summary>
-    /// If the call to the API fails, this method is called to load the previously parsed configuration.
-    /// If the previously parsed configuration is not found, an exception is thrown.
-    /// </summary>
-    /// <param name="builder">The WebApplicationBuilder to add the configuration to.</param>
-    /// <param name="file">The file that contains the previously parsed configuration.</param>
-    /// <returns>The WebApplicationBuilder with the configuration added.</returns>
-    /// <exception cref="FileNotFoundException">Thrown when the previously parsed configuration file is not found.</exception>
-    private static WebApplicationBuilder AddPreviouslyParsedConfiguration(this WebApplicationBuilder builder, string file)
-    {
-        if (!File.Exists(file))
-            throw new FileNotFoundException($"An old parsed configuration not found, file: {file}");
-        builder.Configuration.AddJsonFile(file, false, true);
-        return builder;
     }
 }


### PR DESCRIPTION
https://github.com/poteb/ConfigurationService/issues/191

On successful API call, a second copy of the resolved Parsed.json is
written to a persistent directory (C:\ProgramData\pote\ConfigurationCache)
outside the deployment folder. When the config service is unavailable,
the fallback chain now tries: local Parsed.json → persistent cache → fail
with a clear error listing all attempted locations.

Cache writes are non-fatal — failures are logged but do not block startup.
The feature defaults to enabled and requires no changes in consuming apps.