### PR TITLE
Remove optional error handling in AddConfigurationFromApi (#193)

### DIFF
--- a/src/Config.Middleware/Config.Middleware.Net/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.Net/ExtensionMethods.cs
@@ -6,7 +6,7 @@ namespace pote.Config.Middleware;
 
 public static class ExtensionMethods
 {
-    public static async Task<IConfigurationBuilder> AddConfigurationFromApi(this IConfigurationBuilder builder, BuilderConfiguration configuration, string inputJson, Func<HttpClient> clientProvider, Action<string, Exception> errorOutput = null!)
+    public static async Task<IConfigurationBuilder> AddConfigurationFromApi(this IConfigurationBuilder builder, BuilderConfiguration configuration, string inputJson, Func<HttpClient> clientProvider, Action<string, Exception> errorOutput)
     {
         var parsedJsonFile = Path.Combine(configuration.WorkingDirectory, $"appsettings.{configuration.Environment}.Parsed.json");
         try
@@ -20,7 +20,7 @@ public static class ExtensionMethods
         }
         catch (Exception ex)
         {
-            errorOutput("Error getting configuration from API. Loading previously parsed configuration.", ex);
+            errorOutput?.Invoke("Error getting configuration from API. Loading previously parsed configuration.", ex);
             return builder.AddPreviouslyParsedConfiguration(parsedJsonFile);
         }
     }

--- a/src/Config.Middleware/Config.Middleware.NetStandard/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.NetStandard/ExtensionMethods.cs
@@ -5,7 +5,7 @@ namespace pote.Config.Middleware;
 
 public static class ExtensionMethods
 {
-    public static async Task<IConfigurationBuilder> AddConfigurationFromApi(this IConfigurationBuilder builder, BuilderConfiguration configuration, string inputJson, Func<HttpClient> clientProvider, Action<string, Exception> errorOutput = null!)
+    public static async Task<IConfigurationBuilder> AddConfigurationFromApi(this IConfigurationBuilder builder, BuilderConfiguration configuration, string inputJson, Func<HttpClient> clientProvider, Action<string, Exception> errorOutput)
     {
         var parsedJsonFile = Path.Combine(configuration.WorkingDirectory, $"appsettings.{configuration.Environment}.Parsed.json");
         try
@@ -19,7 +19,7 @@ public static class ExtensionMethods
         }
         catch (Exception ex)
         {
-            errorOutput("Error getting configuration from API. Loading previously parsed configuration.", ex);
+            errorOutput?.Invoke("Error getting configuration from API. Loading previously parsed configuration.", ex);
             return builder.AddPreviouslyParsedConfiguration(parsedJsonFile);
         }
     }


### PR DESCRIPTION
https://github.com/poteb/ConfigurationService/issues/193
Makes the errorOutput action a required parameter in the method signature and adds a null-safe invocation check to prevent potential exceptions during error handling.
