### PR TITLE
Collapse panels on reference navigation and reset test results

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls -la /d/git/ConfigurationService/src/Config.Admin.WebClient/Config.Admin.WebClient/Pages/EditConfiguration.razor* /d/git/ConfigurationService/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContent* /d/git/ConfigurationService/src/Config.Admin.WebClient/Config.Admin.WebClient/Services/ConfigurationTestService.cs)"
+    ]
+  }
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Admin.Api",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-admin-api",
+            "program": "${workspaceFolder}/src/Config.Admin.Api/bin/Debug/net10.0/pote.Config.Admin.Api.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Config.Admin.Api",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+        {
+            "name": "Admin.WebClient",
+            "type": "blazorwasm",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/src/Config.Admin.WebClient/Config.Admin.WebClient",
+            "url": "http://localhost:5071",
+            "browser": "edge"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Admin.Api + WebClient",
+            "configurations": ["Admin.Api", "Admin.WebClient"]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-admin-api",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Config.Admin.Api/Config.Admin.Api.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-admin-webclient",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Config.Admin.WebClient/Config.Admin.WebClient/Config.Admin.WebClient.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContent.razor
+++ b/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContent.razor
@@ -77,7 +77,7 @@
 
             <ConfigurationContentTestPanel @ref="_testPanel" AllEnvironments="_allEnvironments" AllApplications="_allApplications" Configuration="Configuration"></ConfigurationContentTestPanel>
             
-            <ConfigurationContentHistory AllEnvironments="_allEnvironments" AllApplications="_allApplications" Configuration="Configuration"></ConfigurationContentHistory>
+            <ConfigurationContentHistory @ref="_historyPanel" AllEnvironments="_allEnvironments" AllApplications="_allApplications" Configuration="Configuration"></ConfigurationContentHistory>
         }
     </ChildContent>
 </MudExpansionPanel>
@@ -85,6 +85,7 @@
 @code {
     private MudExpansionPanel _expansionPanel = null!;
     private ConfigurationContentTestPanel _testPanel = null!;
+    private ConfigurationContentHistory _historyPanel = null!;
     private string _jsonValidationError = string.Empty;
     private List<Application> _allApplications = new();
     private List<ConfigEnvironment> _allEnvironments = new();
@@ -152,6 +153,8 @@
 
     private void OnRefClicked(JsonRef jsonRef)
     {
+        _testPanel?.Collapse();
+        _historyPanel?.Collapse();
         ConfigurationActions.NavigateToReference(jsonRef.File, jsonRef.OpenInNewTab);
     }
 

--- a/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContentHistory.razor
+++ b/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContentHistory.razor
@@ -59,6 +59,12 @@
     [Inject] public IAdminApiService AdminApiService { get; set; } = null!;
     [CascadingParameter] public PageError PageError { get; set; } = null!;
 
+    public void Collapse()
+    {
+        if (_expansionPanel.IsExpanded)
+            _expansionPanel.Collapse();
+    }
+
     private async Task LoadHistory()
     {
         Configuration.History.Clear();

--- a/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContentTestPanel.razor
+++ b/src/Config.Admin.WebClient/Config.Admin.WebClient/Components/ConfigurationContentTestPanel.razor
@@ -83,12 +83,28 @@
     private bool _runningTests;
     private List<ParseResponse> _testResults = new();
     private MudExpansionPanel _expansionPanel = null!;
+    private string _lastConfigurationId = string.Empty;
 
     [Parameter] public Configuration Configuration { get; set; } = null!;
     [Parameter] public List<Application> AllApplications { get; set; } = null!;
     [Parameter] public List<ConfigEnvironment> AllEnvironments { get; set; } = null!;
     [Inject] public IApiService ApiService { get; set; } = null!;
     [Inject] public IConfigurationTestService ConfigurationTestService { get; set; } = null!;
+
+    public void Collapse()
+    {
+        if (_expansionPanel.IsExpanded)
+            _expansionPanel.Collapse();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (Configuration.Id != _lastConfigurationId)
+        {
+            _testResults.Clear();
+            _lastConfigurationId = Configuration.Id;
+        }
+    }
 
     public async Task RunTests()
     {


### PR DESCRIPTION
Collapses the test and history panels when clicking a configuration reference to provide a cleaner transition. Additionally, clears test results in the test panel when switching configurations to ensure stale results are not displayed.