### PR TITLE
Ref #199 Improve config fallback error logging with root cause

### DIFF
--- a/src/Config.Middleware/Config.Middleware.Net/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.Net/ExtensionMethods.cs
@@ -25,11 +25,11 @@ public static class ExtensionMethods
         catch (Exception ex)
         {
             errorOutput?.Invoke("Error getting configuration from API. Loading previously parsed configuration.", ex);
-            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput);
+            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput, ex);
         }
     }
 
-    private static IConfigurationBuilder AddFallbackConfiguration(this IConfigurationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput)
+    private static IConfigurationBuilder AddFallbackConfiguration(this IConfigurationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput, Exception originalApiException)
     {
         if (File.Exists(parsedJsonFile))
             return builder.AddJsonFile(parsedJsonFile, false, true);
@@ -45,7 +45,8 @@ public static class ExtensionMethods
             $"No configuration found. Tried:{Environment.NewLine}" +
             $"  1. Config service API at {configuration.RootApiUri}{Environment.NewLine}" +
             $"  2. Local file: {parsedJsonFile}{Environment.NewLine}" +
-            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}");
+            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}",
+            originalApiException);
     }
 
     private static async Task SaveToPersistentCacheAsync(BuilderConfiguration configuration, string json, Action<string, Exception> errorOutput)

--- a/src/Config.Middleware/Config.Middleware.NetStandard/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.NetStandard/ExtensionMethods.cs
@@ -24,11 +24,11 @@ public static class ExtensionMethods
         catch (Exception ex)
         {
             errorOutput?.Invoke("Error getting configuration from API. Loading previously parsed configuration.", ex);
-            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput);
+            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput, ex);
         }
     }
 
-    private static IConfigurationBuilder AddFallbackConfiguration(this IConfigurationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput)
+    private static IConfigurationBuilder AddFallbackConfiguration(this IConfigurationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput, Exception originalApiException)
     {
         if (File.Exists(parsedJsonFile))
             return builder.AddJsonFile(parsedJsonFile, false, true);
@@ -44,7 +44,8 @@ public static class ExtensionMethods
             $"No configuration found. Tried:{System.Environment.NewLine}" +
             $"  1. Config service API at {configuration.RootApiUri}{System.Environment.NewLine}" +
             $"  2. Local file: {parsedJsonFile}{System.Environment.NewLine}" +
-            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}");
+            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}",
+            originalApiException);
     }
 
     private static void SaveToPersistentCache(BuilderConfiguration configuration, string json, Action<string, Exception> errorOutput)

--- a/src/Config.Middleware/Config.Middleware.Web.Net/ExtensionMethods.cs
+++ b/src/Config.Middleware/Config.Middleware.Web.Net/ExtensionMethods.cs
@@ -37,11 +37,11 @@ public static class ExtensionMethods
         catch (Exception ex)
         {
             errorOutput("Error getting configuration from API. Loading previously parsed configuration.", ex);
-            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput);
+            return builder.AddFallbackConfiguration(parsedJsonFile, configuration, errorOutput, ex);
         }
     }
 
-    private static WebApplicationBuilder AddFallbackConfiguration(this WebApplicationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput)
+    private static WebApplicationBuilder AddFallbackConfiguration(this WebApplicationBuilder builder, string parsedJsonFile, BuilderConfiguration configuration, Action<string, Exception> errorOutput, Exception originalApiException)
     {
         if (File.Exists(parsedJsonFile))
         {
@@ -61,7 +61,8 @@ public static class ExtensionMethods
             $"No configuration found. Tried:{Environment.NewLine}" +
             $"  1. Config service API at {configuration.RootApiUri}{Environment.NewLine}" +
             $"  2. Local file: {parsedJsonFile}{Environment.NewLine}" +
-            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}");
+            $"  3. Persistent cache: {persistentFile ?? "(disabled)"}",
+            originalApiException);
     }
 
     private static async Task SaveToPersistentCacheAsync(BuilderConfiguration configuration, string json, Action<string, Exception> errorOutput)


### PR DESCRIPTION
https://github.com/poteb/ConfigurationService/issues/199
When configuration fetching from the API fails and the system resorts to fallback mechanisms, the original API exception is now included as an inner exception in the final error. This provides crucial context for diagnosing why configuration loading ultimately failed.
