### PR TITLE
Admin page user login with swappable auth provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,16 @@ cd src/Config.Admin.WebClient && npm run gen:api   # requires Admin API running
 - **Config.Auth** — API key authentication (`X-API-Key` header)
 
 ### Data provider abstraction
-- **Config.DataProvider.Interfaces** — `IDataProvider`, `IAdminDataProvider`, `IApplicationDataAccess`, `IEnvironmentDataAccess`, `ISecretDataAccess`
-- **Config.DataProvider.File** — File-based storage implementation (production-ready)
-- **Config.DataProvider.SqlServer** — SQL Server provider (incomplete)
+- **Config.DataProvider.Interfaces** — `IDataProvider`, `IAdminDataProvider`, `IApplicationDataAccess`, `IEnvironmentDataAccess`, `ISecretDataAccess`, `IUserDataAccess`
+- **Config.DataProvider.SqlServer** — SQL Server provider (primary and default; Dapper + numbered `CreateScripts/`, deployed manually in order)
+- **Config.DataProvider.File** — File-based storage (legacy; no user storage — admin login requires SqlServer)
 
-Both APIs must point to the same `FileDatabase.Directory` and use the same `EncryptionSettings.JsonEncryptionKey`.
+Both APIs must point to the same database (`SqlServer:ConnectionString`) and use the same `EncryptionSettings.JsonEncryptionKey`.
+
+### Admin authentication
+- Admin API + WebClient use DB-backed session login (see `docs/plans/2026-08-04-admin-login-design.md` and ADRs 0002–0005); Config.Api keeps `X-API-Key` for middleware clients.
+- Auth code lives in `src/Config.Admin.Api/Auth/` behind the pluggable `IAuthProviderSetup` seam. Claims contract: `name`, `role` (`Admin`|`User`), `guest`.
+- Bootstrap: empty `Users` table seeds `guest`/`guest`, which can only create the first admin and is hard-deleted on the first real login.
 
 ### Middleware (client-side NuGet packages)
 Located in `src/Config.Middleware/`:
@@ -70,6 +75,7 @@ Located in `src/Config.Middleware/`:
 - **$ref syntax**: `$ref:ConfigName#PropertyPath` resolves references; empty path after `#` takes the entire config
 - **"Base" convention**: A property named `base`/`Base` causes its resolved value to replace the parent object entirely
 - **Application/Environment scoping**: Configurations can be scoped to specific apps and environments for per-context overrides
+- **Glossary**: `CONTEXT.md` at the repo root is the ubiquitous language; ADRs live in `docs/adr/`
 
 ## Testing
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,10 @@ Ubiquitous language for ConfigurationService. Terms here are domain concepts, no
 
 ## Admin identity & access
 
-- **Real User** — A person who can log in to the admin page. Every real user is a full administrator. Avoid: account, admin, member.
-- **Guest User** — The bootstrap user (`guest`/`guest`) that exists whenever the user store is empty. Can do exactly one thing: create a real user. Deleted — not disabled — the first time a real user logs in. Avoid: default user, setup user.
+- **Real User** — A person who can log in to the admin page. Has a Role. Avoid: account, member.
+- **Role** — What a real user may do: `Admin` (user management plus everything else) or `User` (everything except user management).
+- **Guest User** — The bootstrap user (`guest`/`guest`) that exists whenever the user store is empty. Can do exactly one thing: create the first Admin. Deleted — not disabled (and not soft-deleted) — the first time a real user logs in. Avoid: default user, setup user.
+- **Restore** — Reactivating a soft-deleted real user with their old password and role. The counterpart of the repo-wide soft delete, applied to users.
 - **Invite** — Permission for a named person to become a real user by setting their own password, delivered as a link. Single-use, expires. Real users are created only by invite (or by the guest user). Avoid: registration, signup.
 - **Reset Link** — The same mechanism as an invite, but targeting an existing real user who needs a new password. Avoid: forgot-password flow.
 - **Redemption** — Consuming an invite or reset link: the holder sets a password and is logged in.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,4 +13,14 @@ Ubiquitous language for ConfigurationService. Terms here are domain concepts, no
 - **Unhandled application / environment** — An application or environment not covered by any active section of a header. Shown on the editor as a coverage gap.
 - **Test** — Resolving one section's JSON through the parser for one Application × Environment combination. A section's test runs all combinations; a header's test runs all its sections.
 - **Usage** — An occurrence of a configuration referencing an entity (configuration, application, or environment), derived from the dependency graph. Always loaded on demand.
-- **API key** — The `X-API-Key` credential required by both APIs. Admin-client keys use the `csk_` prefix.
+- **API key** — The `X-API-Key` credential used by middleware clients calling the public Config API. Admin-client keys use the `csk_` prefix. Not a login mechanism for humans; the Admin API uses Sessions instead.
+
+## Admin identity & access
+
+- **Real User** — A person who can log in to the admin page. Every real user is a full administrator. Avoid: account, admin, member.
+- **Guest User** — The bootstrap user (`guest`/`guest`) that exists whenever the user store is empty. Can do exactly one thing: create a real user. Deleted — not disabled — the first time a real user logs in. Avoid: default user, setup user.
+- **Invite** — Permission for a named person to become a real user by setting their own password, delivered as a link. Single-use, expires. Real users are created only by invite (or by the guest user). Avoid: registration, signup.
+- **Reset Link** — The same mechanism as an invite, but targeting an existing real user who needs a new password. Avoid: forgot-password flow.
+- **Redemption** — Consuming an invite or reset link: the holder sets a password and is logged in.
+- **Session** — A revocable grant of admin-page access created by logging in. Expires after a fixed lifetime; deleting it ends access immediately. Avoid: JWT, bearer token (implementation terms).
+- **Auth Provider** — The pluggable source of identity for the admin page. `Local` (database users) is the first; OIDC-based providers (ADFS, IdentityServer, Entra) can be added later.

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The green box shows the configuration for the *Test02* environment and the same 
 There is not reference in this example, but it's referenced by another configuration, the *Base-DeliveryNotesApi* configuration. You can see this to the right of the name field.
 
 ## Storage
-The underlying storage is abstracted away from the JSON parser and admin API, which means it's relatively easy to change it. For now you'll find a working file storage data provider and an incomplete SQL Server data provider. Changing the file location is done in *Config.Api/appsettings.Development.json* and *Config.Admin.Api/appsettings.Development.json*.
+The underlying storage is abstracted away from the JSON parser and admin API, which means it's relatively easy to change it. **SQL Server is the primary data provider** (and the default; see ADR-0005) — set `SqlServer:ConnectionString` and run the scripts in `src/Config.DataProvider.SqlServer/CreateScripts/` in order. A file-based provider still exists (`DataProvider: "File"`) but is considered legacy and does not support admin login.
 
 ## Middleware
 *Config.Middleware* contains an extension method for calling and adding the generated configuration to .NET's configuration builder. `IConfigurationBuilder` if .NET Standard and `WebApplicationBuilder` for .NET 6 applications.
@@ -411,9 +411,28 @@ The underlying storage is abstracted away from the JSON parser and admin API, wh
 If the call to the API fails it will try to load a previously generated configuration file instead. If this fails a `FileNotFoundException` is thrown.
 
 ## Security
-None. So don't expose the APIs outside your network.
 
-There are two issues that will add api-key security. [#125](https://github.com/poteb/ConfigurationService/issues/125) and [#126](https://github.com/poteb/ConfigurationService/issues/126).
+- **Config.Api** (middleware-facing): API-key authentication via the `X-API-Key` header. Keys are managed on the admin page.
+- **Admin API + admin page**: user login (see below). The old static admin API key is gone.
+
+### Admin login
+
+The admin page requires a login. Authentication is database-backed (SQL Server provider required) with revocable sessions — no IdentityServer/ADFS/OIDC dependency (the architecture supports adding OIDC providers later, see ADR-0002).
+
+**First run / claiming an instance.** When the user store is empty, the instance seeds a bootstrap user `guest` / `guest`. Guest can do exactly one thing: create the first administrator. Log in as guest immediately after deployment, create your own admin user (you'll be logged in as it right away), and the guest user is deleted — permanently, until the user store is empty again.
+
+- **Users are invite-only**: an admin enters a username + role and gets a single-use link (valid 7 days) to hand over; the invitee sets their own password. No email infrastructure.
+- **Roles**: `Admin` (user management plus everything else) and `User` (everything except user management). The last active admin can never be deleted or demoted.
+- **Password reset**: an admin generates a one-time reset link. Redeeming it revokes all of the user's existing sessions. Logged-in users can change their own password.
+- **Password policy**: at least 16 characters with an uppercase letter, a lowercase letter, a digit, and a special character.
+- **Deleting users**: soft delete by default (restorable, username stays reserved); permanent delete is an explicit second step. Deleting a user ends their sessions immediately.
+- **Disaster recovery** (last admin locked out): delete all rows in the `Users` table and restart the Admin API — the guest user is reborn.
+- **Audit log**: user management, logins, and failed login attempts are recorded in the `AuditLog` table with the acting username and action.
+- Login endpoints are rate-limited per IP. Sessions last 8 hours (configurable via `Auth:SessionLifetimeHours`).
+
+### Adding an auth provider
+
+Authentication is pluggable (ADR-0002): the app authorizes purely on claims (`name`, `role`, and a `guest` claim only the local provider issues). To add a provider (e.g. OIDC for ADFS/IdentityServer/Entra), implement `IAuthProviderSetup` in the Admin API — it contributes service registrations, an authentication handler, and anonymous provider metadata served by `GET api/auth/provider`, which the SPA uses to adapt its login UI. An OIDC provider is validation-only: no user table, no guest, no local endpoints.
 
 ## Build and Deployment
 
@@ -476,8 +495,14 @@ dotnet build
 **Configuration (appsettings.json):**
 ```json
 {
-  "FileDatabase": {
-    "Directory": "C:\\ConfigurationDatabase"
+  "DataProvider": "SqlServer",
+  "SqlServer": {
+    "ConnectionString": "Data Source=.;Database=ConfigurationService;Integrated Security=true;Encrypt=False"
+  },
+  "Auth": {
+    "Provider": "Local",
+    "SessionLifetimeHours": 8,
+    "InviteLifetimeDays": 7
   },
   "WithOrigins": [
     "http://localhost:5071"
@@ -518,8 +543,7 @@ The static site is written to `src/Config.Admin.WebClient/build/`. Convenience s
 **Configuration (static/config.json, deployed next to index.html):**
 ```json
 {
-  "adminApiUrl": "http://localhost:34246",
-  "apiKey": "YourApiKeyHere"
+  "adminApiUrl": "http://localhost:34246"
 }
 ```
 The file is fetched at runtime, so the same build can be deployed to any environment by swapping `config.json`.
@@ -538,14 +562,22 @@ The build output can be hosted on any static file server. A `web.config` with th
 
 ### Deployment Checklist
 
-1. Create a shared directory for configuration storage (e.g., `C:\ConfigurationDatabase` or `/var/configurationdb`)
-2. Ensure both APIs have read/write access to this directory
+1. Create the SQL Server database and run the scripts in `src/Config.DataProvider.SqlServer/CreateScripts/` in order (on upgrades, run only the new ones — they are numbered)
+2. Point both APIs at the database via `SqlServer:ConnectionString`
 3. Generate a secure 32-byte encryption key and use the same key in both APIs
 4. Configure the Admin API's CORS settings to allow the Admin Client origin
-5. Update the Admin Client's appsettings.json with the correct API URLs
+5. Update the Admin Client's `config.json` with the correct Admin API URL
 6. Start the Configuration API first
 7. Start the Admin API second
 8. Deploy and access the Admin Client
+9. **Claim the instance**: log in as `guest`/`guest` and create your admin user immediately
+
+### Upgrading from the API-key version
+
+- The Admin API no longer accepts `X-API-Key`; humans log in, scripts call `POST api/auth/login` first
+- Remove `apiKey` from the Admin Client's `config.json`
+- Run the new `CreateScripts` (`15_Users.sql`–`19_AlterAuditLog_AddUsernameAndAction.sql`) on the existing database
+- The default `DataProvider` is now `SqlServer`; file-based deployments must migrate to use admin login
 
 ### Docker Deployment (Optional)
 

--- a/docs/adr/0002-pluggable-auth-provider.md
+++ b/docs/adr/0002-pluggable-auth-provider.md
@@ -1,0 +1,27 @@
+# 0002 — Pluggable auth provider; the app consumes claims, never issuance details
+
+**Status:** Accepted (2026-08-04)
+
+## Context
+
+The admin page gets database-backed login now, but ADFS/IdentityServer/OIDC login may come
+later, and as an open-source project the auth mechanism must be extendable by others.
+
+## Decision
+
+Authentication is selected by config (`Auth:Provider`). Each provider implements a
+registration seam (`IAuthProviderSetup`) contributing its service registrations, its
+token-validation setup, and optionally its own endpoints. Everything outside the provider
+authorizes on claims (`name`, plus a `guest` claim only the Local provider ever issues) and
+never on how the token was minted. The SPA asks `GET /api/auth/provider` (anonymous) what
+provider is active and adapts its login UI; otherwise it only ever forwards an opaque token.
+
+Invite/reset/guest/user-management are features of the Local provider, not of the app — they
+drop out of the request path entirely when another provider is active.
+
+## Consequences
+
+- A future OIDC provider is validation-only (JwtBearer against an external authority): no user
+  table, no guest, no local endpoints.
+- Mixed mode (two providers at once) and mapping external identities to local user records are
+  explicitly out of scope until needed.

--- a/docs/adr/0003-db-backed-sessions.md
+++ b/docs/adr/0003-db-backed-sessions.md
@@ -1,0 +1,21 @@
+# 0003 — DB-backed sessions instead of self-signed JWTs for local auth
+
+**Status:** Accepted (2026-08-04)
+
+## Context
+
+The Local auth provider needs a way to keep users logged in. The obvious path is self-signed
+JWTs, but those require signing-key management (config burden, multi-instance key sync,
+restart invalidation when auto-generated) and are irrevocable until expiry — which conflicts
+with hard guarantees we want (guest deletion is terminal; deleting a user ends their access).
+
+## Decision
+
+Local sessions are opaque random tokens stored in a `Sessions` table and validated by DB
+lookup per request. Deleting the row revokes access immediately; deleting a user (or the
+guest) deletes their sessions. No signing key exists, so load-balanced instances and restarts
+need zero coordination. Fixed 8-hour absolute lifetime; expired rows cleaned up
+opportunistically.
+
+The per-request DB lookup is irrelevant at admin-UI traffic levels. External OIDC providers
+(ADR-0002) still use stateless JWT validation — this decision is Local-provider-only.

--- a/docs/adr/0004-guest-bootstrap-user.md
+++ b/docs/adr/0004-guest-bootstrap-user.md
@@ -1,0 +1,27 @@
+# 0004 — Guest bootstrap user; empty user store resurrects it
+
+**Status:** Accepted (2026-08-04)
+
+## Context
+
+A fresh instance needs a way to create the first real user without a setup wizard, CLI tool,
+or email infrastructure. Locked-out-last-admin recovery needs an answer too.
+
+## Decision
+
+Whenever the user store is empty at startup, the instance seeds user `guest` / password
+`guest`, which can only create a real user (direct username+password form). Guest is deleted —
+not disabled — the first time a real user logs in (redeeming an invite counts). Until then
+guest keeps working, protecting against typo'd usernames and lost invites. Disaster recovery
+is the same mechanism: delete all user rows, restart, log in as guest.
+
+Alternatives rejected: first-run setup wizard (more code, and an unauthenticated setup page is
+its own attack surface); CLI user creation (hostile to container deployments); config-file
+admin credentials (secrets in config, no rotation story).
+
+## Consequences
+
+- The well-known guest/guest credential is live until the first real login — acceptable
+  because the instance is unusable-by-design until then (guest can only create users), and
+  operators are expected to claim the instance immediately after deployment.
+- Username `guest` is reserved forever.

--- a/docs/adr/0005-sqlserver-primary-provider.md
+++ b/docs/adr/0005-sqlserver-primary-provider.md
@@ -1,0 +1,22 @@
+# 0005 — SQL Server is the primary data provider; File is legacy
+
+**Status:** Accepted (2026-08-04)
+
+## Context
+
+The repo historically treated the file-based data provider as production-ready and SQL Server
+as incomplete. Direction has reversed: the file provider is likely end-of-life.
+
+## Decision
+
+New persistence features (starting with admin login's user/token/session storage) are
+implemented in the SQL Server provider only; the File provider gets `NotSupportedException`
+stubs. The default `DataProvider` setting flips from `File` to `SqlServer`. The Admin API
+fails fast at startup if the active auth provider requires user storage the data provider
+doesn't support.
+
+## Consequences
+
+- Fresh clones must configure a SQL Server connection string before the Admin API starts.
+- Existing file-based deployments cannot use admin login; upgrading them means migrating to
+  SQL Server (loud release note required).

--- a/docs/plans/2026-08-04-admin-login-design.md
+++ b/docs/plans/2026-08-04-admin-login-design.md
@@ -102,8 +102,10 @@ New `IUserDataAccess` in `Config.DataProvider.Interfaces`; Dapper implementation
   blunt brute force; no lockout machinery.
   **Side effect: successful non-guest login deletes the guest user.**
 - `POST /api/auth/redeem` `{token, password}` → creates the user (invite) or sets the password
-  (reset), then auto-logs-in and returns the same shape as login. Expired/unknown/used token →
-  400 with a generic message.
+  (reset), then auto-logs-in and returns the same shape as login — and therefore also triggers
+  guest deletion. Expired/unknown/used token → 400 with a generic message. Edge rules: invite
+  redemption fails if the username was taken in the meantime; reset redemption fails if the
+  user no longer exists.
 - `POST /api/auth/change-password` `{currentPassword, newPassword}` — authenticated, non-guest.
 - `GET /api/auth/provider` — anonymous provider metadata (see seam above).
 
@@ -161,7 +163,8 @@ with a deny-guest policy. Config.Api is untouched.
 ## Security posture (accepted for v1)
 
 - No rate limiting beyond the fixed failure delay; no account lockout.
-- No refresh tokens; JWTs are irrevocable until expiry (8 h).
+- No refresh tokens; JWTs are irrevocable until expiry (8 h). This includes tokens of users
+  deleted mid-session — a deleted user keeps API access for up to 8 hours.
 - Raw (unhashed) one-time tokens stored in the DB — an attacker with DB write access could
   mint credentials anyway.
 - HTTPS is assumed to be handled by deployment/reverse proxy.

--- a/docs/plans/2026-08-04-admin-login-design.md
+++ b/docs/plans/2026-08-04-admin-login-design.md
@@ -1,9 +1,10 @@
 # Admin login — design
 
 Date: 2026-08-04
-Status: Approved (brainstorm + grilling complete)
+Status: Approved (brainstorm + grilling + external review complete)
 Related: ADR-0002 (pluggable auth provider), ADR-0003 (DB-backed sessions),
-ADR-0004 (guest bootstrap user), ADR-0005 (SQL Server primary provider), CONTEXT.md glossary.
+ADR-0004 (guest bootstrap user), ADR-0005 (SQL Server primary provider), CONTEXT.md glossary,
+spec-review triage in `2026-08-04-admin-login-spec-review.md`.
 
 ## Goal
 
@@ -19,60 +20,69 @@ later (this is an open-source project; the auth mechanism must fit anyone and be
    Config.Api (middleware-facing) keeps API-key auth, untouched.
 2. **Session mechanism**: DB-backed sessions (ADR-0003). Login stores an opaque random
    256-bit token in a `Sessions` table; the SPA sends it as `Authorization: Bearer <token>`
-   via the existing seam in `src/lib/api/client.ts`; validation is a DB lookup per request.
-   Fixed 8-hour absolute lifetime, no refresh. Sessions are revocable: deleting a user (or
-   guest) deletes their sessions and ends access immediately. Logout deletes the session row.
-   No signing keys — restarts and load-balanced instances need zero coordination.
-3. **Password reset**: Admin-driven — any real user can generate a one-time reset link for
-   another user. No SMTP/email anywhere. A logged-in real user can always change their own
-   password.
-4. **Invites**: New users only by invite. The inviter fixes the username; the invitee opens a
-   single-use link (valid 7 days) and sets their password. Invite links and reset links are
-   the same mechanism: a token that authorizes setting the password for a username.
+   via the existing seam in `src/lib/api/client.ts`; validation is a DB lookup per request
+   that joins the user row — so role changes, soft deletes, and hard deletes take effect on
+   the next request. Fixed 8-hour absolute lifetime, no refresh. Logout deletes the session
+   row. No signing keys — restarts and load-balanced instances need zero coordination.
+3. **Password reset**: Admin-driven — an **admin** can generate a one-time reset link for
+   another user. No SMTP/email anywhere. Redeeming a reset link revokes all of that user's
+   existing sessions before issuing the new one (resets are used after compromise; old
+   sessions must die). A logged-in real user can always change their own password
+   (current-password verified); doing so revokes their *other* sessions.
+4. **Invites**: New users only by invite. The inviting admin fixes the username **and role**;
+   the invitee opens a single-use link (valid 7 days) and sets their password. Invites and
+   reset links are the same concept (a token authorizing a password set) but live in separate
+   tables because invites target a username+role that has no user row yet, while resets
+   target an existing user.
 5. **Guest user** (ADR-0004):
    - A new instance is born with user `guest` / password `guest`.
-   - Guest can do exactly one thing: directly create a real user (username + password form —
-     no invite-link ceremony, since the person at the keyboard is the new user).
-   - Guest is **deleted** (not disabled) the first time a real user logs in. Redeeming an
-     invite auto-logs-in and counts. Deletion cascades to guest's sessions, so a lingering
-     guest login dies with it.
+   - Guest can do exactly one thing: directly create the first Admin (username + password
+     form — no invite-link ceremony, since the person at the keyboard is the new user).
+   - Guest is **deleted** (hard, not soft) the first time a real user logs in. Redeeming an
+     invite auto-logs-in and counts. Deletion cascades to guest's sessions.
    - Until a real user has logged in, guest keeps working and can create more users
-     (protects against typo'd usernames / lost invites).
-   - **Empty user store ⇒ guest is (re)created at startup.** Bootstrap and disaster recovery
-     ("last admin locked out": delete all user rows, restart) are the same mechanism.
+     (protects against typo'd usernames / lost invites). While guest exists, the Admin API
+     logs a prominent startup warning ("instance unclaimed — log in as guest and create a
+     user now").
+   - **Empty user store ⇒ guest is (re)created at startup**, as an idempotent insert that
+     treats losing a duplicate-key race (multi-instance startup) as success. Bootstrap and
+     disaster recovery ("last admin locked out": delete all user rows, restart) are the same
+     mechanism.
 6. **Roles**: Two — `Admin` and `User`. Admins do user management (invite, delete/restore,
    reset links, role assignment) plus everything else; Users do everything else (configs,
    secrets, environments, API keys) but nothing user-related except changing their own
-   password. Invites carry the role, chosen by the inviting admin. The user guest creates is
-   always an Admin. **The last active admin cannot be deleted or demoted.** `LastLoginUtc` is
-   tracked and shown in the user list so admins can spot stale accounts (e.g. leavers).
+   password. The user guest creates is always an Admin. **The last active admin cannot be
+   deleted or demoted.** `LastLoginUtc` is tracked and shown in the user list so admins can
+   spot stale accounts (e.g. leavers).
 7. **Storage** (ADR-0005): SQL Server provider only; the File provider gets
    `NotSupportedException` stubs. The default `DataProvider` becomes `SqlServer`. If the
    active auth provider needs user storage the data provider can't supply, the Admin API
    **fails fast at startup** with a clear message.
-8. **Username rules**: trimmed, 1–100 chars, case-insensitive unique (SQL Server default
-   collation) and case-insensitive at login; displayed as first entered. `guest` reserved
-   case-insensitively.
-9. **Password policy**: minimum 16 characters, at least one lowercase, one uppercase, one
-   digit, one special character. Applies everywhere a password is chosen (redemption,
-   change-password, guest's direct create). The seeded `guest`/`guest` credential is exempt
-   (fixed bootstrap credential, not user-chosen).
+8. **Username rules**: trimmed; 1–100 chars; allowed characters are letters, digits, and
+   `. - _ @` (covers email-style names, excludes path separators, control characters, and
+   bidi tricks); case-insensitive unique via an explicit case-insensitive collation on the
+   column (never "whatever the server default is") and case-insensitive at login; displayed
+   as first entered. `guest` reserved case-insensitively.
+9. **Password policy**: 16–128 characters (length checked before any hashing), at least one
+   lowercase, one uppercase, one digit, one special character. Applies everywhere a password
+   is chosen. The seeded `guest`/`guest` credential is exempt (fixed bootstrap credential).
 10. **Uniform errors**: login always returns the same 401 regardless of what was wrong;
-    redemption failures return one generic 400 ("invalid or expired link") without
-    distinguishing expired/used/unknown. ~500 ms delay on failed login; no lockout.
+    redemption failures return one generic 400 ("invalid or expired link"). Unknown-user
+    logins run a dummy hash verification so response *timing* is uniform too, and failures
+    complete no sooner than a minimum response time (~500 ms) rather than adding an
+    unconditional sleep. Login and redeem endpoints are rate-limited per IP (ASP.NET Core
+    rate limiter, e.g. 10/min) — brute-force *and* resource-exhaustion mitigation.
 11. **User deletion is soft** (repo convention): a `Deleted` flag; sessions revoked and
     outstanding tokens removed immediately; login refused. Username uniqueness spans live and
     soft-deleted users — inviting a soft-deleted username → 400 ("restore instead"). Restore
     (admin-only) reactivates the account with its old password hash + role; pair with a reset
     link if the password is forgotten. **Permanent delete** is the explicit second step,
-    available only on already-soft-deleted users; it frees the username, and the audit log
-    remains the historical record. Guest resurrection triggers only on a truly empty Users
-    table (soft-deleted rows count as existing); DB-level recovery (delete all rows, restart)
-    is unchanged. Guest itself is still hard-deleted on first real login.
-12. **Audit log gets first-class columns**: `Username` (acting user, `NVARCHAR(100) NULL`)
-    and `Action` (`NVARCHAR(50)`, e.g. `Insert`, `Delete`, `Login`, `LoginFailed`,
-    `InviteCreated`). `Content` becomes optional free-form detail — today it misleadingly
-    holds only the action verb.
+    available only on already-soft-deleted users; it frees the username (FKs cascade the
+    remaining sessions/resets away), and the audit log remains the historical record. Guest
+    resurrection triggers only on a truly empty Users table (soft-deleted rows count as
+    existing); DB-level recovery (delete all rows, restart) is unchanged.
+12. **Audit log gets first-class columns**: `Username` (acting user) and `Action`. See
+    Audit logging below.
 
 ## Architecture
 
@@ -82,18 +92,20 @@ later (this is an open-source project; the auth mechanism must fit anyone and be
 
 - Config setting `Auth:Provider` selects the provider. This feature implements `"Local"`.
   A future `"Oidc"` provider covers ADFS / IdentityServer / Entra / any OIDC authority.
+- **Claims contract** (the provider-agnostic boundary): `name` (username), `role`
+  (`Admin` | `User`), and `guest` (only Local ever issues it). Authorization policies are
+  built exclusively on these claims. A future OIDC provider must map external claims/groups
+  into `role` as part of its setup — that mapping is the provider's job, not the app's.
 - Backend seam: an `IAuthProviderSetup` registration interface. Each provider contributes:
   service registrations, authentication-handler configuration, and optionally its own
   endpoints.
 
   `Local` contributes: the `AuthController` (login/logout/redeem/change-password), user
   management, the stores (`IUserDataAccess`), guest bootstrap, and an authentication handler
-  that validates opaque bearer tokens against the `Sessions` table.
+  that validates opaque bearer tokens against the `Sessions` table (joined to `Users`, so
+  claims always reflect the *current* row: current role, not-deleted).
   A future `Oidc` provider contributes only standard JwtBearer validation against the
   external authority — no local endpoints, no user table, no guest.
-- Everything outside the provider is provider-agnostic: controllers authorize on **claims**
-  (`name`, plus a `guest` claim only Local ever issues), never on how the identity was
-  established.
 - Frontend seam: anonymous `GET /api/auth/provider` returns provider metadata.
   `{type: "local"}` → SPA shows the login form. Future `{type: "oidc", authority, clientId}` →
   redirect-based flow. The SPA auth store and `client.ts` deal only in "current token" —
@@ -105,90 +117,130 @@ identities to local user records.
 
 ### Data model (SqlServer `CreateScripts`)
 
+All tables: `NOT NULL` everywhere except where noted; `CHECK` constraints on enum-like
+columns; explicit case-insensitive collation (`Latin1_General_100_CI_AS`) on every username
+column; indexes on every expiry column (cleanup + validation paths).
+
 `15_Users.sql`:
 
-| Column       | Type                | Notes                          |
-|--------------|---------------------|--------------------------------|
-| Id           | UNIQUEIDENTIFIER PK |                                |
-| Username     | NVARCHAR(100)       | unique (case-insensitive), spans deleted users |
-| PasswordHash | NVARCHAR(500)       | ASP.NET Core PasswordHasher    |
-| Role         | NVARCHAR(20)        | `Admin` \| `User`              |
-| IsGuest      | BIT                 |                                |
-| Deleted      | BIT                 | soft delete                    |
-| CreatedUtc   | DATETIME2           |                                |
-| LastLoginUtc | DATETIME2 NULL      | updated on login               |
+| Column       | Type                | Notes                                        |
+|--------------|---------------------|----------------------------------------------|
+| Id           | UNIQUEIDENTIFIER PK |                                              |
+| Username     | NVARCHAR(100)       | unique index, CI collation, spans deleted    |
+| PasswordHash | NVARCHAR(500)       | ASP.NET Core PasswordHasher                  |
+| Role         | NVARCHAR(20)        | CHECK: `Admin` \| `User`                     |
+| IsGuest      | BIT                 | default 0                                    |
+| Deleted      | BIT                 | default 0 (soft delete)                      |
+| CreatedUtc   | DATETIME2           |                                              |
+| LastLoginUtc | DATETIME2 NULL      | updated on login                             |
 
-`16_UserTokens.sql`:
+`16_UserInvites.sql` (no user row exists yet, so no FK):
 
-| Column     | Type             | Notes                                  |
-|------------|------------------|----------------------------------------|
-| Token      | NVARCHAR(100) PK | random 256-bit, url-safe               |
-| Username   | NVARCHAR(100)    | target user                            |
-| Purpose    | NVARCHAR(20)     | `invite` \| `reset`                    |
-| ExpiresUtc | DATETIME2        | now + 7 days                           |
+| Column     | Type                | Notes                                          |
+|------------|---------------------|------------------------------------------------|
+| Id         | UNIQUEIDENTIFIER    | stable identity for audit EntityId             |
+| Token      | NVARCHAR(100) PK    | random 256-bit, url-safe                       |
+| Username   | NVARCHAR(100)       | unique index (one active invite per username)  |
+| Role       | NVARCHAR(20)        | CHECK: `Admin` \| `User`                       |
+| CreatedBy  | NVARCHAR(100)       | inviting admin's username                      |
+| ExpiresUtc | DATETIME2           | now + 7 days, indexed                          |
 
-`17_Sessions.sql`:
+`17_PasswordResets.sql`:
 
-| Column     | Type             | Notes                                  |
-|------------|------------------|----------------------------------------|
-| Token      | NVARCHAR(100) PK | random 256-bit, url-safe               |
-| Username   | NVARCHAR(100)    |                                        |
-| IsGuest    | BIT              |                                        |
-| CreatedUtc | DATETIME2        |                                        |
-| ExpiresUtc | DATETIME2        | now + 8 h (absolute)                   |
+| Column     | Type                | Notes                                          |
+|------------|---------------------|------------------------------------------------|
+| Id         | UNIQUEIDENTIFIER    | audit EntityId                                 |
+| Token      | NVARCHAR(100) PK    | random 256-bit, url-safe                       |
+| UserId     | UNIQUEIDENTIFIER    | FK → Users ON DELETE CASCADE; unique (one active reset per user) |
+| ExpiresUtc | DATETIME2           | now + 7 days, indexed                          |
+
+`18_Sessions.sql`:
+
+| Column     | Type                | Notes                                          |
+|------------|---------------------|------------------------------------------------|
+| Token      | NVARCHAR(100) PK    | random 256-bit, url-safe                       |
+| UserId     | UNIQUEIDENTIFIER    | FK → Users ON DELETE CASCADE                   |
+| CreatedUtc | DATETIME2           |                                                |
+| ExpiresUtc | DATETIME2           | now + 8 h (absolute), indexed                  |
+
+Sessions and resets are keyed to the immutable `UserId` (never the reusable username), so
+hard deletes cascade in the database itself rather than relying on application deletes.
+Invites are the one username-keyed table by necessity.
 
 Token lifecycle rules:
 
-- One active token per (username, purpose): creating a new invite/reset replaces the old one.
-- Inviting a username that already exists as a user → 400.
-- Tokens are single-use: deleted on redemption. Expired token/session rows are cleaned up
-  opportunistically (on login and token creation).
+- One active token per target (DB-enforced unique indexes above): creating a new invite/reset
+  replaces the old one.
+- Inviting a username that already exists as a user → 400 (live) / 400 "restore instead"
+  (soft-deleted).
+- Tokens are single-use: consumed with an atomic delete-and-check (`DELETE ... OUTPUT` /
+  affected-row check inside the redemption transaction) so concurrent redemptions cannot
+  both succeed. Expiry is authoritative at validation time regardless of cleanup.
+- Expired rows are cleaned up opportunistically (on login and token creation) in bounded
+  batches (`DELETE TOP (n)`), backed by the expiry indexes.
 - Pending invites can be revoked (`DELETE /api/users/invites/{username}`).
-- A reset link whose user was deleted fails at redemption and is swept by cleanup.
 
-New `IUserDataAccess` in `Config.DataProvider.Interfaces` (users, tokens, sessions); Dapper
-implementation in `Config.DataProvider.SqlServer`; stub in `Config.DataProvider.File` (throws
-`NotSupportedException`: "user login requires the SqlServer provider").
+New `IUserDataAccess` in `Config.DataProvider.Interfaces` (users, invites, resets, sessions);
+Dapper implementation in `Config.DataProvider.SqlServer`; stub in `Config.DataProvider.File`
+(throws `NotSupportedException`: "user login requires the SqlServer provider").
+
+### Concurrency & atomicity (required, not optional)
+
+- Token redemption: single transaction — consume token (affected-row check), create/update
+  user, revoke prior sessions (resets), create session.
+- Last-active-admin rail: the demote/soft-delete statement itself re-checks the invariant
+  inside the transaction (`UPDATE ... WHERE (SELECT COUNT(*) FROM Users WHERE Role='Admin'
+  AND Deleted=0 AND Id <> @id) > 0`-style), so concurrent demotions can't strand the system.
+- Guest bootstrap: idempotent insert; duplicate-key loss of the race = success.
+- Password change: update hash + revoke other sessions in one transaction.
+- `PasswordHasher` rehash-on-verify: when verification returns `SuccessRehashNeeded`, update
+  the stored hash concurrency-safely (guarded by the old hash value so a concurrent password
+  change wins).
 
 ### Endpoints (Admin API)
 
-`AuthController` (anonymous unless noted):
+`AuthController` (anonymous unless noted; login + redeem rate-limited per IP):
 
-- `POST /api/auth/login` `{username, password}` → `{token, expiresUtc, username, isGuest}` or
-  uniform 401 (~500 ms delay on failure).
-  **Side effect: successful real-user login deletes the guest user and guest sessions.**
-- `POST /api/auth/redeem` `{token, password}` → creates the user (invite) or sets the password
-  (reset), then auto-logs-in and returns the same shape as login — and therefore also triggers
-  guest deletion. Edge rules: invite redemption fails if the username was taken in the
-  meantime; reset redemption fails if the user no longer exists. Failures → generic 400.
+- `POST /api/auth/login` `{username, password}` →
+  `{token, expiresUtc, username, role, isGuest}` or uniform 401 (uniform timing, minimum
+  response duration). Updates `LastLoginUtc`.
+  **Side effect: successful real-user login deletes the guest user (cascades guest
+  sessions).**
+- `POST /api/auth/redeem` `{token, password}` → creates the user (invite, with the invite's
+  role) or sets the password (reset, revoking all prior sessions), then auto-logs-in and
+  returns the same shape as login — and therefore also triggers guest deletion. Edge rules:
+  invite redemption fails if the username was taken in the meantime; reset redemption fails
+  if the user no longer exists or is soft-deleted. Failures → generic 400.
 - `POST /api/auth/logout` (authenticated) — deletes the session row.
 - `POST /api/auth/change-password` `{currentPassword, newPassword}` — authenticated, real
-  users only.
+  users only. Revokes the user's other sessions.
 - `GET /api/auth/provider` — anonymous provider metadata (see seam above).
+
+Auth responses carrying tokens set `Cache-Control: no-store`. Session and one-time tokens,
+passwords, and `Authorization` headers are never written to application logs.
 
 `UsersController` (session required; user management is **admin-only**):
 
 - `GET /api/users` — users (incl. soft-deleted, with `deleted`, `role`, `lastLoginUtc`) +
-  pending invites (with expiry). Admins only.
-- `POST /api/users/invites` `{username, role}` → `{token, expiresUtc}`. Admins only. The SPA
-  composes the link as `<its own origin>/redeem?token=...` — the backend never needs to know
-  the SPA's URL.
-- `DELETE /api/users/invites/{username}` — revoke a pending invite. Admins only.
-- `POST /api/users/{username}/reset` → `{token, expiresUtc}`. Admins only.
-- `PUT /api/users/{username}/role` `{role}` — admins only; cannot demote the last active
-  admin.
-- `DELETE /api/users/{username}` — soft delete. Admins only; cannot delete yourself; cannot
-  delete the last active admin. Revokes the user's sessions and outstanding tokens.
-- `POST /api/users/{username}/restore` — admins only; reactivates a soft-deleted user with
-  old password hash and role.
-- `DELETE /api/users/{username}?permanent=true` — admins only; only valid on an already
-  soft-deleted user; frees the username.
+  pending invites (username, role, createdBy, expiry).
+- `POST /api/users/invites` `{username, role}` → `{token, expiresUtc}`. The SPA composes the
+  link as `<its own origin>/redeem#token=...` — the backend never needs to know the SPA's
+  URL.
+- `DELETE /api/users/invites/{username}` — revoke a pending invite.
+- `POST /api/users/{username}/reset` → `{token, expiresUtc}`.
+- `PUT /api/users/{username}/role` `{role}` — cannot demote the last active admin.
+- `DELETE /api/users/{username}` — soft delete; cannot delete yourself; cannot delete the
+  last active admin. Revokes the user's sessions and outstanding resets.
+- `POST /api/users/{username}/restore` — reactivates a soft-deleted user with old password
+  hash and role.
+- `DELETE /api/users/{username}?permanent=true` — only valid on an already soft-deleted
+  user; frees the username; FKs cascade remaining rows.
 - `POST /api/users` `{username, password}` — **guest-only** direct create of the first Admin
   (real users are invite-only; guest gets the direct form).
 
 Guest policy: a guest session may only call `POST /api/users` and `POST /api/auth/logout`
-(plus the anonymous endpoints). Everything else → 403. Guest deletion revokes guest sessions,
-so the policy needs no existence re-checks.
+(plus the anonymous endpoints). Everything else → 403. Guest deletion cascades guest
+sessions, so the policy needs no existence re-checks.
 
 Authorization layers: anonymous (login/redeem/provider) → authenticated real user (all
 config/secret/environment/API-key endpoints, own password change, logout) → admin (user
@@ -200,8 +252,8 @@ Config.Api is untouched.
 
 ### Bootstrap & configuration
 
-- Startup (Local provider only): if the `Users` table is empty, insert `guest` with hashed
-  password `guest`. Runs on every startup.
+- Startup (Local provider only): if the `Users` table is empty, insert `guest` (idempotent,
+  race-safe). Runs on every startup. While guest exists, log a prominent warning.
 - Startup validation: `Auth:Provider=Local` + a data provider without user-storage support →
   fail fast with a clear message.
 - New `AuthSettings`: `SessionLifetimeHours` = 8, `InviteLifetimeDays` = 7 (applies to reset
@@ -211,13 +263,16 @@ Config.Api is untouched.
 
 ### Frontend (SvelteKit SPA)
 
-- `/login` page. Auth store holds `{token, expiresUtc, username, isGuest}` in localStorage.
+- `/login` page. Auth store holds `{token, expiresUtc, username, role, isGuest}` in
+  localStorage.
 - `client.ts` seam sends `Authorization: Bearer`; any 401 clears the session and redirects to
   `/login`. The static `apiKey` in `config.json` is removed.
 - Layout guard: no token → `/login`. Guest token → locked to a single "create your first real
   user" screen.
-- `/redeem?token=...` page: set password (×2, policy validated client- and server-side),
-  auto-login, navigate home.
+- `/redeem` page reads the token from the **URL fragment** (`#token=...`, never the query
+  string — fragments don't reach server logs or `Referer` headers), immediately strips it
+  with `history.replaceState`, then: set password (×2, policy validated client- and
+  server-side), auto-login, navigate home. The app sets a restrictive `Referrer-Policy`.
 - Users admin page (admins only; hidden for role `User`): list users with role, last login,
   and deleted state ("show deleted" toggle); create invite with role (copyable link); revoke
   pending invite; generate reset link (copyable); change role; soft delete; restore;
@@ -227,22 +282,26 @@ Config.Api is untouched.
 
 ### Audit logging
 
-The `AuditLog` table gains two first-class columns (fresh installs via updated
-`13_AuditLog.sql`; existing databases via idempotent `18_AlterAuditLog_AddUsernameAndAction.sql`):
+The `AuditLog` table gains two columns (fresh installs via updated `13_AuditLog.sql`;
+existing databases via idempotent `19_AlterAuditLog_AddUsernameAndAction.sql`):
 
 - **`Username`** `NVARCHAR(100) NULL` — the acting user (from the session). `NULL` for rows
   predating login or written by non-user paths. (`User` is a reserved word in T-SQL.)
-- **`Action`** `NVARCHAR(50)` — `Insert`, `Delete`, `Save`, `Login`, `LoginFailed`,
+- **`Action`** `NVARCHAR(50) NULL` — `Insert`, `Delete`, `Save`, `Login`, `LoginFailed`,
   `InviteCreated`, `InviteRevoked`, `ResetLinkCreated`, `PasswordChanged`, `RoleChanged`,
-  `UserRestored`, `UserPermanentlyDeleted`, ... Today the action verb hides in `Content`;
-  after this, `Content` becomes optional free-form detail (e.g. the target username of an
-  invite).
-- User events: `EntityType="User"`, `EntityId` = the target user's GUID (usernames exceed the
-  36-char column). The actor is the `Username` column.
+  `UserRestored`, `UserPermanentlyDeleted`, ... Nullable because historical rows predate it;
+  the alter script backfills `Action` from the legacy `Content` value (which today holds
+  only the action verb), after which `Content` is optional free-form detail. All new writes
+  set `Action`.
+- `EntityId` semantics (column is NVARCHAR(36), so always a GUID or empty): user events →
+  the target user's GUID; invite events → the invite's `Id` GUID; failed logins →
+  `Guid.Empty` with the attempted username (truncated to 100 chars) in `Content`. The actor
+  is always the `Username` column. Caller IP remains the direct connection IP (existing
+  behavior; no forwarded-header parsing).
 - Logged events: user created (by whom), user soft/permanently deleted, restored, role
   changed, invite created/revoked, reset link created, password changed, login success, and
-  **login failure** (attempted username + IP — the only brute-force visibility given no
-  lockout).
+  **login failure** (the only brute-force fingerprint given no lockout; write volume is
+  bounded by the login rate limiter).
 
 ### Testing
 
@@ -250,9 +309,11 @@ The `AuditLog` table gains two first-class columns (fresh installs via updated
   issue/validate/revoke/expiry, redemption paths (incl. username-taken and user-deleted
   edges), token replace/revoke rules, password policy, role policies (admin-only user
   management, last-active-admin rail for delete and demote), soft delete/restore/permanent
-  delete semantics, fail-fast provider check — against mocked `IUserDataAccess`. Dapper
-  implementations stay unit-untested, consistent with the rest of the repo (no SQL Server
-  integration-test infrastructure in this feature).
+  delete semantics, session revocation on reset/change-password, fail-fast provider check —
+  against mocked `IUserDataAccess`. Dapper implementations stay unit-untested, consistent
+  with the rest of the repo (no SQL Server integration-test infrastructure in this feature;
+  recorded as accepted risk in the review triage — the concurrency-sensitive SQL uses
+  affected-row patterns reviewed by hand).
 - **Frontend (Vitest)**: auth store (persistence, expiry), `client.ts` (bearer header,
   401 → clear session + redirect).
 - **E2E (Playwright, mocked routes — no real backend, unchanged pattern)**: login happy path,
@@ -264,23 +325,30 @@ The `AuditLog` table gains two first-class columns (fresh installs via updated
 - Default `DataProvider` is now `SqlServer`; a connection string is required. File-based
   deployments cannot use admin login (startup fails fast) — migrating to SQL Server is the
   upgrade path.
-- New `CreateScripts` `15_Users.sql`, `16_UserTokens.sql`, `17_Sessions.sql`, and
-  `18_AlterAuditLog_AddUsernameAndAction.sql` must be run on existing databases.
-- After upgrade the Users table is empty → guest/guest is live; the first operator to log in
-  should immediately create their user (which kills guest on first real login).
+- New `CreateScripts` `15_Users.sql`–`18_Sessions.sql` and
+  `19_AlterAuditLog_AddUsernameAndAction.sql` must be run on existing databases
+  (`13_AuditLog.sql` is updated for fresh installs; 19 is idempotent either way).
+- After upgrade the Users table is empty → guest/guest is live; **claim the instance
+  immediately**: log in as guest, create your admin user (which kills guest on first real
+  login). The startup warning nags until claimed.
 - README + CLAUDE.md updated: setup flow, SQL Server as primary provider, auth documentation,
   "adding an auth provider" extension guide.
 
 ## Security posture (accepted for v1)
 
-- No rate limiting beyond the fixed failure delay; no account lockout. Failed logins are
-  audit-logged.
-- Sessions are revocable (DB-backed); logout, user deletion, and guest deletion take effect
-  immediately. Absolute 8 h lifetime, no refresh/sliding.
+- Login/redeem rate-limited per IP; ~minimum-response-time on failures; no account lockout.
+  Failed logins are audit-logged.
+- Sessions are revocable (DB-backed, user-joined on every request); logout, user deletion,
+  soft deletion, demotion, and guest deletion take effect on the next request. Absolute 8 h
+  lifetime, no refresh/sliding.
 - Session token in localStorage: accepted XSS trade-off for a static SPA (no cookie
   infrastructure); the SPA has no third-party script includes.
 - Raw (unhashed) one-time tokens and session tokens stored in the DB — an attacker with DB
   write access could mint credentials anyway.
 - The well-known guest/guest credential is live until the first real login (ADR-0004) —
-  acceptable because guest can only create users, and operators claim instances immediately.
+  an explicit product decision; mitigations are the guest's minimal capability, the startup
+  warning, and the "claim immediately" rollout instruction.
+- Restore reactivates the old password hash by design (admin's judgment whether to pair it
+  with a reset link).
+- Audit-log retention/rotation is out of scope (matches the table's existing behavior).
 - HTTPS is assumed to be handled by deployment/reverse proxy.

--- a/docs/plans/2026-08-04-admin-login-design.md
+++ b/docs/plans/2026-08-04-admin-login-design.md
@@ -1,7 +1,9 @@
 # Admin login — design
 
 Date: 2026-08-04
-Status: Approved (brainstorm phase)
+Status: Approved (brainstorm + grilling complete)
+Related: ADR-0002 (pluggable auth provider), ADR-0003 (DB-backed sessions),
+ADR-0004 (guest bootstrap user), ADR-0005 (SQL Server primary provider), CONTEXT.md glossary.
 
 ## Goal
 
@@ -9,57 +11,75 @@ Add user login to the ConfigurationService admin page. Simple database-backed au
 no IdentityServer/ADFS/Google for now — but architected so the identity provider is swappable
 later (this is an open-source project; the auth mechanism must fit anyone and be extendable).
 
-## Decisions (from brainstorm interview)
+## Decisions
 
-1. **Scope**: Login replaces the static `X-API-Key` for the Admin API. The SPA no longer ships
-   an API key in `static/config.json`. Config.Api (middleware-facing) keeps API-key auth,
-   untouched.
-2. **Session mechanism**: JWT bearer token, 8-hour lifetime, no refresh tokens. The SPA sends
-   `Authorization: Bearer <token>` via the existing seam in `src/lib/api/client.ts`.
-3. **Password reset**: Admin-driven — any logged-in (non-guest) user can generate a one-time
-   reset link for another user. No SMTP/email anywhere. A logged-in user can always change
-   their own password.
+1. **Scope**: Login replaces the static `X-API-Key` for the Admin API — a clean break, no
+   grace period (the key shipped to every browser and was never a real boundary; scripts can
+   `POST /api/auth/login` instead). The SPA no longer ships an API key in `static/config.json`.
+   Config.Api (middleware-facing) keeps API-key auth, untouched.
+2. **Session mechanism**: DB-backed sessions (ADR-0003). Login stores an opaque random
+   256-bit token in a `Sessions` table; the SPA sends it as `Authorization: Bearer <token>`
+   via the existing seam in `src/lib/api/client.ts`; validation is a DB lookup per request.
+   Fixed 8-hour absolute lifetime, no refresh. Sessions are revocable: deleting a user (or
+   guest) deletes their sessions and ends access immediately. Logout deletes the session row.
+   No signing keys — restarts and load-balanced instances need zero coordination.
+3. **Password reset**: Admin-driven — any real user can generate a one-time reset link for
+   another user. No SMTP/email anywhere. A logged-in real user can always change their own
+   password.
 4. **Invites**: New users only by invite. The inviter fixes the username; the invitee opens a
-   single-use link (valid 7 days) and sets their password. Invite links and reset links are the
-   same mechanism: a token that authorizes setting the password for a username.
-5. **Guest user**:
+   single-use link (valid 7 days) and sets their password. Invite links and reset links are
+   the same mechanism: a token that authorizes setting the password for a username.
+5. **Guest user** (ADR-0004):
    - A new instance is born with user `guest` / password `guest`.
    - Guest can do exactly one thing: directly create a real user (username + password form —
      no invite-link ceremony, since the person at the keyboard is the new user).
-   - Guest is **deleted** (not disabled) the first time a real (non-guest) user logs in.
-     Redeeming an invite auto-logs-in and counts as a login.
+   - Guest is **deleted** (not disabled) the first time a real user logs in. Redeeming an
+     invite auto-logs-in and counts. Deletion cascades to guest's sessions, so a lingering
+     guest login dies with it.
    - Until a real user has logged in, guest keeps working and can create more users
      (protects against typo'd usernames / lost invites).
    - **Empty user store ⇒ guest is (re)created at startup.** Bootstrap and disaster recovery
      ("last admin locked out": delete all user rows, restart) are the same mechanism.
 6. **Roles**: None. Every real user is a full admin. Guest is the only special case.
-7. **Storage**: SQL Server provider is the focus (file provider is likely end-of-life). File
-   provider gets a stub that throws `NotSupportedException` with a clear message.
+7. **Storage** (ADR-0005): SQL Server provider only; the File provider gets
+   `NotSupportedException` stubs. The default `DataProvider` becomes `SqlServer`. If the
+   active auth provider needs user storage the data provider can't supply, the Admin API
+   **fails fast at startup** with a clear message.
+8. **Username rules**: trimmed, 1–100 chars, case-insensitive unique (SQL Server default
+   collation) and case-insensitive at login; displayed as first entered. `guest` reserved
+   case-insensitively.
+9. **Password policy**: minimum 16 characters, at least one lowercase, one uppercase, one
+   digit, one special character. Applies everywhere a password is chosen (redemption,
+   change-password, guest's direct create). The seeded `guest`/`guest` credential is exempt
+   (fixed bootstrap credential, not user-chosen).
+10. **Uniform errors**: login always returns the same 401 regardless of what was wrong;
+    redemption failures return one generic 400 ("invalid or expired link") without
+    distinguishing expired/used/unknown. ~500 ms delay on failed login; no lockout.
 
 ## Architecture
 
-### Swappable identity provider (the load-bearing seam)
+### Swappable identity provider (ADR-0002)
 
-**The app consumes standard JWT bearer identities; how tokens are issued is the pluggable part.**
+**The app consumes claims-based identities; how they're established is the pluggable part.**
 
 - Config setting `Auth:Provider` selects the provider. This feature implements `"Local"`.
   A future `"Oidc"` provider covers ADFS / IdentityServer / Entra / any OIDC authority.
 - Backend seam: an `IAuthProviderSetup` registration interface. Each provider contributes:
-  - service registrations,
-  - JWT-validation configuration,
-  - optionally its own endpoints.
+  service registrations, authentication-handler configuration, and optionally its own
+  endpoints.
 
-  `Local` contributes the `AuthController` (login/redeem/change-password), user management,
-  the user store (`IUserDataAccess`), guest bootstrap, and validation of its self-signed JWTs.
-  A future `Oidc` provider contributes only JwtBearer validation against the external
-  authority — no local endpoints, no user table, no guest user.
+  `Local` contributes: the `AuthController` (login/logout/redeem/change-password), user
+  management, the stores (`IUserDataAccess`), guest bootstrap, and an authentication handler
+  that validates opaque bearer tokens against the `Sessions` table.
+  A future `Oidc` provider contributes only standard JwtBearer validation against the
+  external authority — no local endpoints, no user table, no guest.
 - Everything outside the provider is provider-agnostic: controllers authorize on **claims**
-  (`name`, plus a `guest` claim only Local ever issues), never on how the token was minted.
-  Invite/reset/guest/user-management are Local-only features and drop out of the request path
-  when another provider is active.
+  (`name`, plus a `guest` claim only Local ever issues), never on how the identity was
+  established.
 - Frontend seam: anonymous `GET /api/auth/provider` returns provider metadata.
   `{type: "local"}` → SPA shows the login form. Future `{type: "oidc", authority, clientId}` →
-  redirect-based flow. The SPA auth store and `client.ts` deal only in "current token".
+  redirect-based flow. The SPA auth store and `client.ts` deal only in "current token" —
+  opaque bytes either way.
 - Docs: add a short "adding an auth provider" section (public extension point).
 
 Out of scope now: implementing OIDC, mixed mode (two providers at once), mapping external
@@ -72,70 +92,89 @@ identities to local user records.
 | Column       | Type                | Notes                        |
 |--------------|---------------------|------------------------------|
 | Id           | UNIQUEIDENTIFIER PK |                              |
-| Username     | NVARCHAR(100)       | unique                       |
+| Username     | NVARCHAR(100)       | unique (case-insensitive)    |
 | PasswordHash | NVARCHAR(500)       | ASP.NET Core PasswordHasher  |
 | IsGuest      | BIT                 |                              |
 | CreatedUtc   | DATETIME2           |                              |
 
 `16_UserTokens.sql`:
 
-| Column     | Type           | Notes                                  |
-|------------|----------------|----------------------------------------|
-| Token      | NVARCHAR(100) PK | random 256-bit, url-safe             |
-| Username   | NVARCHAR(100)  | target user                            |
-| Purpose    | NVARCHAR(20)   | `invite` \| `reset`                    |
-| ExpiresUtc | DATETIME2      | now + 7 days                           |
+| Column     | Type             | Notes                                  |
+|------------|------------------|----------------------------------------|
+| Token      | NVARCHAR(100) PK | random 256-bit, url-safe               |
+| Username   | NVARCHAR(100)    | target user                            |
+| Purpose    | NVARCHAR(20)     | `invite` \| `reset`                    |
+| ExpiresUtc | DATETIME2        | now + 7 days                           |
 
-Tokens are single-use: deleted on redemption. Username `guest` is reserved (cannot be invited
-or created).
+`17_Sessions.sql`:
 
-New `IUserDataAccess` in `Config.DataProvider.Interfaces`; Dapper implementation in
-`Config.DataProvider.SqlServer`; stub in `Config.DataProvider.File` (throws
+| Column     | Type             | Notes                                  |
+|------------|------------------|----------------------------------------|
+| Token      | NVARCHAR(100) PK | random 256-bit, url-safe               |
+| Username   | NVARCHAR(100)    |                                        |
+| IsGuest    | BIT              |                                        |
+| CreatedUtc | DATETIME2        |                                        |
+| ExpiresUtc | DATETIME2        | now + 8 h (absolute)                   |
+
+Token lifecycle rules:
+
+- One active token per (username, purpose): creating a new invite/reset replaces the old one.
+- Inviting a username that already exists as a user → 400.
+- Tokens are single-use: deleted on redemption. Expired token/session rows are cleaned up
+  opportunistically (on login and token creation).
+- Pending invites can be revoked (`DELETE /api/users/invites/{username}`).
+- A reset link whose user was deleted fails at redemption and is swept by cleanup.
+
+New `IUserDataAccess` in `Config.DataProvider.Interfaces` (users, tokens, sessions); Dapper
+implementation in `Config.DataProvider.SqlServer`; stub in `Config.DataProvider.File` (throws
 `NotSupportedException`: "user login requires the SqlServer provider").
 
 ### Endpoints (Admin API)
 
-`AuthController` (anonymous):
+`AuthController` (anonymous unless noted):
 
 - `POST /api/auth/login` `{username, password}` → `{token, expiresUtc, username, isGuest}` or
-  uniform 401 (same response for unknown user / wrong password). ~500 ms delay on failure to
-  blunt brute force; no lockout machinery.
-  **Side effect: successful non-guest login deletes the guest user.**
+  uniform 401 (~500 ms delay on failure).
+  **Side effect: successful real-user login deletes the guest user and guest sessions.**
 - `POST /api/auth/redeem` `{token, password}` → creates the user (invite) or sets the password
   (reset), then auto-logs-in and returns the same shape as login — and therefore also triggers
-  guest deletion. Expired/unknown/used token → 400 with a generic message. Edge rules: invite
-  redemption fails if the username was taken in the meantime; reset redemption fails if the
-  user no longer exists.
-- `POST /api/auth/change-password` `{currentPassword, newPassword}` — authenticated, non-guest.
+  guest deletion. Edge rules: invite redemption fails if the username was taken in the
+  meantime; reset redemption fails if the user no longer exists. Failures → generic 400.
+- `POST /api/auth/logout` (authenticated) — deletes the session row.
+- `POST /api/auth/change-password` `{currentPassword, newPassword}` — authenticated, real
+  users only.
 - `GET /api/auth/provider` — anonymous provider metadata (see seam above).
 
-`UsersController` (JWT required):
+`UsersController` (session required):
 
-- `GET /api/users` — users + pending invites (with expiry). Non-guest only.
-- `POST /api/users/invites` `{username}` → `{token, expiresUtc}`. Non-guest only. The SPA
+- `GET /api/users` — users + pending invites (with expiry). Real users only.
+- `POST /api/users/invites` `{username}` → `{token, expiresUtc}`. Real users only. The SPA
   composes the link as `<its own origin>/redeem?token=...` — the backend never needs to know
   the SPA's URL.
-- `POST /api/users/{username}/reset` → `{token, expiresUtc}`. Non-guest only.
-- `DELETE /api/users/{username}` — non-guest only; cannot delete yourself. (Deleting the last
-  user directly in the DB is the designed recovery path.)
+- `DELETE /api/users/invites/{username}` — revoke a pending invite. Real users only.
+- `POST /api/users/{username}/reset` → `{token, expiresUtc}`. Real users only.
+- `DELETE /api/users/{username}` — real users only; cannot delete yourself. (Deleting the last
+  user directly in the DB is the designed recovery path.) Deletes the user's sessions and
+  outstanding tokens.
 - `POST /api/users` `{username, password}` — **guest-only** direct create (real users are
   invite-only; guest gets the direct form).
 
-Guest policy: a guest JWT may only call `POST /api/users` (plus the anonymous endpoints).
-Everything else → 403.
+Guest policy: a guest session may only call `POST /api/users` and `POST /api/auth/logout`
+(plus the anonymous endpoints). Everything else → 403. Guest deletion revokes guest sessions,
+so the policy needs no existence re-checks.
 
 All existing Admin API controllers switch from `ApiKeyAuthenticationFilter` to `[Authorize]`
-with a deny-guest policy. Config.Api is untouched.
+with a deny-guest policy. Swagger security definition switches from `X-API-Key` to bearer.
+Config.Api is untouched.
 
 ### Bootstrap & configuration
 
 - Startup (Local provider only): if the `Users` table is empty, insert `guest` with hashed
   password `guest`. Runs on every startup.
-- New `AuthSettings`:
-  - `JwtSigningKey` — if empty, auto-generate at startup and log a warning (restart then
-    invalidates sessions).
-  - `TokenLifetimeHours` = 8
-  - `InviteLifetimeDays` = 7
+- Startup validation: `Auth:Provider=Local` + a data provider without user-storage support →
+  fail fast with a clear message.
+- New `AuthSettings`: `SessionLifetimeHours` = 8, `InviteLifetimeDays` = 7 (applies to reset
+  links too).
 - Password hashing: ASP.NET Core standalone `PasswordHasher` (PBKDF2, format-versioned)
   from `Microsoft.Extensions.Identity.Core` — no EF, no Identity schema.
 
@@ -146,25 +185,61 @@ with a deny-guest policy. Config.Api is untouched.
   `/login`. The static `apiKey` in `config.json` is removed.
 - Layout guard: no token → `/login`. Guest token → locked to a single "create your first real
   user" screen.
-- `/redeem?token=...` page: set password (×2), auto-login, navigate home.
-- Users admin page: list users, create invite (copyable link), generate reset link (copyable),
-  delete user, pending invites with expiry.
-- Change-password in the header menu.
+- `/redeem?token=...` page: set password (×2, policy validated client- and server-side),
+  auto-login, navigate home.
+- Users admin page: list users, create invite (copyable link), revoke pending invite,
+  generate reset link (copyable), delete user.
+- Change-password and logout in the header menu.
+- Regenerate API types (`npm run gen:api`).
 
-### Audit & testing
+### Audit logging
 
-- User actions (login, user created/deleted, invite/reset created, password changed) go
-  through the existing audit-log handler, stamped with the acting username from the JWT.
-- NUnit: auth service (guest lifecycle, redemption paths, expiry/reuse rejection, hashing,
-  login side effects) with NSubstitute'd `IUserDataAccess`.
-- Vitest: auth store, client seam (401 handling, bearer header).
-- Playwright: one e2e for the login flow.
+Via the existing generic `AuditLog` table (`EntityType`, `EntityId`, `CallerIp`, `Content`):
+
+- `EntityType="User"`, `EntityId` = the user's GUID (usernames exceed the 36-char column;
+  they go in `Content`).
+- Events: user created (by whom), user deleted, invite created/revoked, reset link created,
+  password changed, login success, **login failure** (attempted username + IP — the only
+  brute-force visibility given no lockout).
+- Acting user on existing entity audits (configs/environments/apps/settings/secrets): the
+  acting username is included in the JSON `Content` payload — no `ALTER TABLE`, no schema
+  migration for existing deployments.
+
+### Testing
+
+- **Backend (NUnit + NSubstitute)**: auth service logic — guest lifecycle, session
+  issue/validate/revoke/expiry, redemption paths (incl. username-taken and user-deleted
+  edges), token replace/revoke rules, password policy, fail-fast provider check — against
+  mocked `IUserDataAccess`. Dapper implementations stay unit-untested, consistent with the
+  rest of the repo (no SQL Server integration-test infrastructure in this feature).
+- **Frontend (Vitest)**: auth store (persistence, expiry), `client.ts` (bearer header,
+  401 → clear session + redirect).
+- **E2E (Playwright, mocked routes — no real backend, unchanged pattern)**: login happy path,
+  guest → create-first-user flow, invite redemption.
+
+## Rollout (breaking changes — release notes required)
+
+- Admin API requires login; `X-API-Key` no longer accepted there. Scripts must log in first.
+- Default `DataProvider` is now `SqlServer`; a connection string is required. File-based
+  deployments cannot use admin login (startup fails fast) — migrating to SQL Server is the
+  upgrade path.
+- New `CreateScripts` `15_Users.sql`, `16_UserTokens.sql`, `17_Sessions.sql` must be run on
+  existing databases.
+- After upgrade the Users table is empty → guest/guest is live; the first operator to log in
+  should immediately create their user (which kills guest on first real login).
+- README + CLAUDE.md updated: setup flow, SQL Server as primary provider, auth documentation,
+  "adding an auth provider" extension guide.
 
 ## Security posture (accepted for v1)
 
-- No rate limiting beyond the fixed failure delay; no account lockout.
-- No refresh tokens; JWTs are irrevocable until expiry (8 h). This includes tokens of users
-  deleted mid-session — a deleted user keeps API access for up to 8 hours.
-- Raw (unhashed) one-time tokens stored in the DB — an attacker with DB write access could
-  mint credentials anyway.
+- No rate limiting beyond the fixed failure delay; no account lockout. Failed logins are
+  audit-logged.
+- Sessions are revocable (DB-backed); logout, user deletion, and guest deletion take effect
+  immediately. Absolute 8 h lifetime, no refresh/sliding.
+- Session token in localStorage: accepted XSS trade-off for a static SPA (no cookie
+  infrastructure); the SPA has no third-party script includes.
+- Raw (unhashed) one-time tokens and session tokens stored in the DB — an attacker with DB
+  write access could mint credentials anyway.
+- The well-known guest/guest credential is live until the first real login (ADR-0004) —
+  acceptable because guest can only create users, and operators claim instances immediately.
 - HTTPS is assumed to be handled by deployment/reverse proxy.

--- a/docs/plans/2026-08-04-admin-login-design.md
+++ b/docs/plans/2026-08-04-admin-login-design.md
@@ -1,0 +1,167 @@
+# Admin login — design
+
+Date: 2026-08-04
+Status: Approved (brainstorm phase)
+
+## Goal
+
+Add user login to the ConfigurationService admin page. Simple database-backed authentication —
+no IdentityServer/ADFS/Google for now — but architected so the identity provider is swappable
+later (this is an open-source project; the auth mechanism must fit anyone and be extendable).
+
+## Decisions (from brainstorm interview)
+
+1. **Scope**: Login replaces the static `X-API-Key` for the Admin API. The SPA no longer ships
+   an API key in `static/config.json`. Config.Api (middleware-facing) keeps API-key auth,
+   untouched.
+2. **Session mechanism**: JWT bearer token, 8-hour lifetime, no refresh tokens. The SPA sends
+   `Authorization: Bearer <token>` via the existing seam in `src/lib/api/client.ts`.
+3. **Password reset**: Admin-driven — any logged-in (non-guest) user can generate a one-time
+   reset link for another user. No SMTP/email anywhere. A logged-in user can always change
+   their own password.
+4. **Invites**: New users only by invite. The inviter fixes the username; the invitee opens a
+   single-use link (valid 7 days) and sets their password. Invite links and reset links are the
+   same mechanism: a token that authorizes setting the password for a username.
+5. **Guest user**:
+   - A new instance is born with user `guest` / password `guest`.
+   - Guest can do exactly one thing: directly create a real user (username + password form —
+     no invite-link ceremony, since the person at the keyboard is the new user).
+   - Guest is **deleted** (not disabled) the first time a real (non-guest) user logs in.
+     Redeeming an invite auto-logs-in and counts as a login.
+   - Until a real user has logged in, guest keeps working and can create more users
+     (protects against typo'd usernames / lost invites).
+   - **Empty user store ⇒ guest is (re)created at startup.** Bootstrap and disaster recovery
+     ("last admin locked out": delete all user rows, restart) are the same mechanism.
+6. **Roles**: None. Every real user is a full admin. Guest is the only special case.
+7. **Storage**: SQL Server provider is the focus (file provider is likely end-of-life). File
+   provider gets a stub that throws `NotSupportedException` with a clear message.
+
+## Architecture
+
+### Swappable identity provider (the load-bearing seam)
+
+**The app consumes standard JWT bearer identities; how tokens are issued is the pluggable part.**
+
+- Config setting `Auth:Provider` selects the provider. This feature implements `"Local"`.
+  A future `"Oidc"` provider covers ADFS / IdentityServer / Entra / any OIDC authority.
+- Backend seam: an `IAuthProviderSetup` registration interface. Each provider contributes:
+  - service registrations,
+  - JWT-validation configuration,
+  - optionally its own endpoints.
+
+  `Local` contributes the `AuthController` (login/redeem/change-password), user management,
+  the user store (`IUserDataAccess`), guest bootstrap, and validation of its self-signed JWTs.
+  A future `Oidc` provider contributes only JwtBearer validation against the external
+  authority — no local endpoints, no user table, no guest user.
+- Everything outside the provider is provider-agnostic: controllers authorize on **claims**
+  (`name`, plus a `guest` claim only Local ever issues), never on how the token was minted.
+  Invite/reset/guest/user-management are Local-only features and drop out of the request path
+  when another provider is active.
+- Frontend seam: anonymous `GET /api/auth/provider` returns provider metadata.
+  `{type: "local"}` → SPA shows the login form. Future `{type: "oidc", authority, clientId}` →
+  redirect-based flow. The SPA auth store and `client.ts` deal only in "current token".
+- Docs: add a short "adding an auth provider" section (public extension point).
+
+Out of scope now: implementing OIDC, mixed mode (two providers at once), mapping external
+identities to local user records.
+
+### Data model (SqlServer `CreateScripts`)
+
+`15_Users.sql`:
+
+| Column       | Type                | Notes                        |
+|--------------|---------------------|------------------------------|
+| Id           | UNIQUEIDENTIFIER PK |                              |
+| Username     | NVARCHAR(100)       | unique                       |
+| PasswordHash | NVARCHAR(500)       | ASP.NET Core PasswordHasher  |
+| IsGuest      | BIT                 |                              |
+| CreatedUtc   | DATETIME2           |                              |
+
+`16_UserTokens.sql`:
+
+| Column     | Type           | Notes                                  |
+|------------|----------------|----------------------------------------|
+| Token      | NVARCHAR(100) PK | random 256-bit, url-safe             |
+| Username   | NVARCHAR(100)  | target user                            |
+| Purpose    | NVARCHAR(20)   | `invite` \| `reset`                    |
+| ExpiresUtc | DATETIME2      | now + 7 days                           |
+
+Tokens are single-use: deleted on redemption. Username `guest` is reserved (cannot be invited
+or created).
+
+New `IUserDataAccess` in `Config.DataProvider.Interfaces`; Dapper implementation in
+`Config.DataProvider.SqlServer`; stub in `Config.DataProvider.File` (throws
+`NotSupportedException`: "user login requires the SqlServer provider").
+
+### Endpoints (Admin API)
+
+`AuthController` (anonymous):
+
+- `POST /api/auth/login` `{username, password}` → `{token, expiresUtc, username, isGuest}` or
+  uniform 401 (same response for unknown user / wrong password). ~500 ms delay on failure to
+  blunt brute force; no lockout machinery.
+  **Side effect: successful non-guest login deletes the guest user.**
+- `POST /api/auth/redeem` `{token, password}` → creates the user (invite) or sets the password
+  (reset), then auto-logs-in and returns the same shape as login. Expired/unknown/used token →
+  400 with a generic message.
+- `POST /api/auth/change-password` `{currentPassword, newPassword}` — authenticated, non-guest.
+- `GET /api/auth/provider` — anonymous provider metadata (see seam above).
+
+`UsersController` (JWT required):
+
+- `GET /api/users` — users + pending invites (with expiry). Non-guest only.
+- `POST /api/users/invites` `{username}` → `{token, expiresUtc}`. Non-guest only. The SPA
+  composes the link as `<its own origin>/redeem?token=...` — the backend never needs to know
+  the SPA's URL.
+- `POST /api/users/{username}/reset` → `{token, expiresUtc}`. Non-guest only.
+- `DELETE /api/users/{username}` — non-guest only; cannot delete yourself. (Deleting the last
+  user directly in the DB is the designed recovery path.)
+- `POST /api/users` `{username, password}` — **guest-only** direct create (real users are
+  invite-only; guest gets the direct form).
+
+Guest policy: a guest JWT may only call `POST /api/users` (plus the anonymous endpoints).
+Everything else → 403.
+
+All existing Admin API controllers switch from `ApiKeyAuthenticationFilter` to `[Authorize]`
+with a deny-guest policy. Config.Api is untouched.
+
+### Bootstrap & configuration
+
+- Startup (Local provider only): if the `Users` table is empty, insert `guest` with hashed
+  password `guest`. Runs on every startup.
+- New `AuthSettings`:
+  - `JwtSigningKey` — if empty, auto-generate at startup and log a warning (restart then
+    invalidates sessions).
+  - `TokenLifetimeHours` = 8
+  - `InviteLifetimeDays` = 7
+- Password hashing: ASP.NET Core standalone `PasswordHasher` (PBKDF2, format-versioned)
+  from `Microsoft.Extensions.Identity.Core` — no EF, no Identity schema.
+
+### Frontend (SvelteKit SPA)
+
+- `/login` page. Auth store holds `{token, expiresUtc, username, isGuest}` in localStorage.
+- `client.ts` seam sends `Authorization: Bearer`; any 401 clears the session and redirects to
+  `/login`. The static `apiKey` in `config.json` is removed.
+- Layout guard: no token → `/login`. Guest token → locked to a single "create your first real
+  user" screen.
+- `/redeem?token=...` page: set password (×2), auto-login, navigate home.
+- Users admin page: list users, create invite (copyable link), generate reset link (copyable),
+  delete user, pending invites with expiry.
+- Change-password in the header menu.
+
+### Audit & testing
+
+- User actions (login, user created/deleted, invite/reset created, password changed) go
+  through the existing audit-log handler, stamped with the acting username from the JWT.
+- NUnit: auth service (guest lifecycle, redemption paths, expiry/reuse rejection, hashing,
+  login side effects) with NSubstitute'd `IUserDataAccess`.
+- Vitest: auth store, client seam (401 handling, bearer header).
+- Playwright: one e2e for the login flow.
+
+## Security posture (accepted for v1)
+
+- No rate limiting beyond the fixed failure delay; no account lockout.
+- No refresh tokens; JWTs are irrevocable until expiry (8 h).
+- Raw (unhashed) one-time tokens stored in the DB — an attacker with DB write access could
+  mint credentials anyway.
+- HTTPS is assumed to be handled by deployment/reverse proxy.

--- a/docs/plans/2026-08-04-admin-login-design.md
+++ b/docs/plans/2026-08-04-admin-login-design.md
@@ -40,7 +40,12 @@ later (this is an open-source project; the auth mechanism must fit anyone and be
      (protects against typo'd usernames / lost invites).
    - **Empty user store ⇒ guest is (re)created at startup.** Bootstrap and disaster recovery
      ("last admin locked out": delete all user rows, restart) are the same mechanism.
-6. **Roles**: None. Every real user is a full admin. Guest is the only special case.
+6. **Roles**: Two — `Admin` and `User`. Admins do user management (invite, delete/restore,
+   reset links, role assignment) plus everything else; Users do everything else (configs,
+   secrets, environments, API keys) but nothing user-related except changing their own
+   password. Invites carry the role, chosen by the inviting admin. The user guest creates is
+   always an Admin. **The last active admin cannot be deleted or demoted.** `LastLoginUtc` is
+   tracked and shown in the user list so admins can spot stale accounts (e.g. leavers).
 7. **Storage** (ADR-0005): SQL Server provider only; the File provider gets
    `NotSupportedException` stubs. The default `DataProvider` becomes `SqlServer`. If the
    active auth provider needs user storage the data provider can't supply, the Admin API
@@ -55,6 +60,19 @@ later (this is an open-source project; the auth mechanism must fit anyone and be
 10. **Uniform errors**: login always returns the same 401 regardless of what was wrong;
     redemption failures return one generic 400 ("invalid or expired link") without
     distinguishing expired/used/unknown. ~500 ms delay on failed login; no lockout.
+11. **User deletion is soft** (repo convention): a `Deleted` flag; sessions revoked and
+    outstanding tokens removed immediately; login refused. Username uniqueness spans live and
+    soft-deleted users — inviting a soft-deleted username → 400 ("restore instead"). Restore
+    (admin-only) reactivates the account with its old password hash + role; pair with a reset
+    link if the password is forgotten. **Permanent delete** is the explicit second step,
+    available only on already-soft-deleted users; it frees the username, and the audit log
+    remains the historical record. Guest resurrection triggers only on a truly empty Users
+    table (soft-deleted rows count as existing); DB-level recovery (delete all rows, restart)
+    is unchanged. Guest itself is still hard-deleted on first real login.
+12. **Audit log gets first-class columns**: `Username` (acting user, `NVARCHAR(100) NULL`)
+    and `Action` (`NVARCHAR(50)`, e.g. `Insert`, `Delete`, `Login`, `LoginFailed`,
+    `InviteCreated`). `Content` becomes optional free-form detail — today it misleadingly
+    holds only the action verb.
 
 ## Architecture
 
@@ -89,13 +107,16 @@ identities to local user records.
 
 `15_Users.sql`:
 
-| Column       | Type                | Notes                        |
-|--------------|---------------------|------------------------------|
-| Id           | UNIQUEIDENTIFIER PK |                              |
-| Username     | NVARCHAR(100)       | unique (case-insensitive)    |
-| PasswordHash | NVARCHAR(500)       | ASP.NET Core PasswordHasher  |
-| IsGuest      | BIT                 |                              |
-| CreatedUtc   | DATETIME2           |                              |
+| Column       | Type                | Notes                          |
+|--------------|---------------------|--------------------------------|
+| Id           | UNIQUEIDENTIFIER PK |                                |
+| Username     | NVARCHAR(100)       | unique (case-insensitive), spans deleted users |
+| PasswordHash | NVARCHAR(500)       | ASP.NET Core PasswordHasher    |
+| Role         | NVARCHAR(20)        | `Admin` \| `User`              |
+| IsGuest      | BIT                 |                                |
+| Deleted      | BIT                 | soft delete                    |
+| CreatedUtc   | DATETIME2           |                                |
+| LastLoginUtc | DATETIME2 NULL      | updated on login               |
 
 `16_UserTokens.sql`:
 
@@ -145,23 +166,33 @@ implementation in `Config.DataProvider.SqlServer`; stub in `Config.DataProvider.
   users only.
 - `GET /api/auth/provider` — anonymous provider metadata (see seam above).
 
-`UsersController` (session required):
+`UsersController` (session required; user management is **admin-only**):
 
-- `GET /api/users` — users + pending invites (with expiry). Real users only.
-- `POST /api/users/invites` `{username}` → `{token, expiresUtc}`. Real users only. The SPA
+- `GET /api/users` — users (incl. soft-deleted, with `deleted`, `role`, `lastLoginUtc`) +
+  pending invites (with expiry). Admins only.
+- `POST /api/users/invites` `{username, role}` → `{token, expiresUtc}`. Admins only. The SPA
   composes the link as `<its own origin>/redeem?token=...` — the backend never needs to know
   the SPA's URL.
-- `DELETE /api/users/invites/{username}` — revoke a pending invite. Real users only.
-- `POST /api/users/{username}/reset` → `{token, expiresUtc}`. Real users only.
-- `DELETE /api/users/{username}` — real users only; cannot delete yourself. (Deleting the last
-  user directly in the DB is the designed recovery path.) Deletes the user's sessions and
-  outstanding tokens.
-- `POST /api/users` `{username, password}` — **guest-only** direct create (real users are
-  invite-only; guest gets the direct form).
+- `DELETE /api/users/invites/{username}` — revoke a pending invite. Admins only.
+- `POST /api/users/{username}/reset` → `{token, expiresUtc}`. Admins only.
+- `PUT /api/users/{username}/role` `{role}` — admins only; cannot demote the last active
+  admin.
+- `DELETE /api/users/{username}` — soft delete. Admins only; cannot delete yourself; cannot
+  delete the last active admin. Revokes the user's sessions and outstanding tokens.
+- `POST /api/users/{username}/restore` — admins only; reactivates a soft-deleted user with
+  old password hash and role.
+- `DELETE /api/users/{username}?permanent=true` — admins only; only valid on an already
+  soft-deleted user; frees the username.
+- `POST /api/users` `{username, password}` — **guest-only** direct create of the first Admin
+  (real users are invite-only; guest gets the direct form).
 
 Guest policy: a guest session may only call `POST /api/users` and `POST /api/auth/logout`
 (plus the anonymous endpoints). Everything else → 403. Guest deletion revokes guest sessions,
 so the policy needs no existence re-checks.
+
+Authorization layers: anonymous (login/redeem/provider) → authenticated real user (all
+config/secret/environment/API-key endpoints, own password change, logout) → admin (user
+management) — with guest outside all of them except its two endpoints.
 
 All existing Admin API controllers switch from `ApiKeyAuthenticationFilter` to `[Authorize]`
 with a deny-guest policy. Swagger security definition switches from `X-API-Key` to bearer.
@@ -187,31 +218,41 @@ Config.Api is untouched.
   user" screen.
 - `/redeem?token=...` page: set password (×2, policy validated client- and server-side),
   auto-login, navigate home.
-- Users admin page: list users, create invite (copyable link), revoke pending invite,
-  generate reset link (copyable), delete user.
+- Users admin page (admins only; hidden for role `User`): list users with role, last login,
+  and deleted state ("show deleted" toggle); create invite with role (copyable link); revoke
+  pending invite; generate reset link (copyable); change role; soft delete; restore;
+  permanent delete (on deleted users, with confirmation).
 - Change-password and logout in the header menu.
 - Regenerate API types (`npm run gen:api`).
 
 ### Audit logging
 
-Via the existing generic `AuditLog` table (`EntityType`, `EntityId`, `CallerIp`, `Content`):
+The `AuditLog` table gains two first-class columns (fresh installs via updated
+`13_AuditLog.sql`; existing databases via idempotent `18_AlterAuditLog_AddUsernameAndAction.sql`):
 
-- `EntityType="User"`, `EntityId` = the user's GUID (usernames exceed the 36-char column;
-  they go in `Content`).
-- Events: user created (by whom), user deleted, invite created/revoked, reset link created,
-  password changed, login success, **login failure** (attempted username + IP — the only
-  brute-force visibility given no lockout).
-- Acting user on existing entity audits (configs/environments/apps/settings/secrets): the
-  acting username is included in the JSON `Content` payload — no `ALTER TABLE`, no schema
-  migration for existing deployments.
+- **`Username`** `NVARCHAR(100) NULL` — the acting user (from the session). `NULL` for rows
+  predating login or written by non-user paths. (`User` is a reserved word in T-SQL.)
+- **`Action`** `NVARCHAR(50)` — `Insert`, `Delete`, `Save`, `Login`, `LoginFailed`,
+  `InviteCreated`, `InviteRevoked`, `ResetLinkCreated`, `PasswordChanged`, `RoleChanged`,
+  `UserRestored`, `UserPermanentlyDeleted`, ... Today the action verb hides in `Content`;
+  after this, `Content` becomes optional free-form detail (e.g. the target username of an
+  invite).
+- User events: `EntityType="User"`, `EntityId` = the target user's GUID (usernames exceed the
+  36-char column). The actor is the `Username` column.
+- Logged events: user created (by whom), user soft/permanently deleted, restored, role
+  changed, invite created/revoked, reset link created, password changed, login success, and
+  **login failure** (attempted username + IP — the only brute-force visibility given no
+  lockout).
 
 ### Testing
 
 - **Backend (NUnit + NSubstitute)**: auth service logic — guest lifecycle, session
   issue/validate/revoke/expiry, redemption paths (incl. username-taken and user-deleted
-  edges), token replace/revoke rules, password policy, fail-fast provider check — against
-  mocked `IUserDataAccess`. Dapper implementations stay unit-untested, consistent with the
-  rest of the repo (no SQL Server integration-test infrastructure in this feature).
+  edges), token replace/revoke rules, password policy, role policies (admin-only user
+  management, last-active-admin rail for delete and demote), soft delete/restore/permanent
+  delete semantics, fail-fast provider check — against mocked `IUserDataAccess`. Dapper
+  implementations stay unit-untested, consistent with the rest of the repo (no SQL Server
+  integration-test infrastructure in this feature).
 - **Frontend (Vitest)**: auth store (persistence, expiry), `client.ts` (bearer header,
   401 → clear session + redirect).
 - **E2E (Playwright, mocked routes — no real backend, unchanged pattern)**: login happy path,
@@ -223,8 +264,8 @@ Via the existing generic `AuditLog` table (`EntityType`, `EntityId`, `CallerIp`,
 - Default `DataProvider` is now `SqlServer`; a connection string is required. File-based
   deployments cannot use admin login (startup fails fast) — migrating to SQL Server is the
   upgrade path.
-- New `CreateScripts` `15_Users.sql`, `16_UserTokens.sql`, `17_Sessions.sql` must be run on
-  existing databases.
+- New `CreateScripts` `15_Users.sql`, `16_UserTokens.sql`, `17_Sessions.sql`, and
+  `18_AlterAuditLog_AddUsernameAndAction.sql` must be run on existing databases.
 - After upgrade the Users table is empty → guest/guest is live; the first operator to log in
   should immediately create their user (which kills guest on first real login).
 - README + CLAUDE.md updated: setup flow, SQL Server as primary provider, auth documentation,

--- a/docs/plans/2026-08-04-admin-login-plan.md
+++ b/docs/plans/2026-08-04-admin-login-plan.md
@@ -1,0 +1,351 @@
+# Admin Login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Database-backed user login for the admin page per `docs/plans/2026-08-04-admin-login-design.md` (the spec — authoritative for all behavior).
+
+**Architecture:** Local auth provider (DB sessions, opaque bearer tokens) behind a pluggable `IAuthProviderSetup` seam. SQL Server storage via Dapper. SvelteKit SPA gets login/redeem/users pages. Claims contract: `name`, `role` (`Admin`|`User`), `guest`.
+
+**Tech Stack:** ASP.NET Core (net10.0), Dapper, `Microsoft.Extensions.Identity.Core` (PasswordHasher), NUnit + NSubstitute, SvelteKit/Svelte 5 + TS, Vitest, Playwright.
+
+## Global Constraints
+
+- Root namespace prefix `pote.` (e.g. `pote.Config.Admin.Api`).
+- Nullable enabled, implicit usings, net10.0 (interfaces lib: follows existing csproj settings).
+- Password policy: 16–128 chars, ≥1 lower, ≥1 upper, ≥1 digit, ≥1 special.
+- Username: trimmed, 1–100, chars `[A-Za-z0-9.\-_@]`, case-insensitive unique; `guest` reserved.
+- Tokens: 256-bit random, url-safe base64 (no padding); single-use; invites/resets 7 days, sessions 8 h absolute.
+- All SQL usernames columns: `COLLATE Latin1_General_100_CI_AS`.
+- Uniform errors: login → plain 401; redeem failure → generic 400. Minimum ~500 ms response time on failed login, dummy-hash for unknown users.
+- Frontend: existing patterns — `ApiResult<T>` from `client.ts`, shadcn-svelte components, Svelte 5 runes.
+- Commit after each task (conventional messages, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`).
+
+---
+
+### Task 1: DbModel entities
+
+**Files:**
+- Create: `src/Config.DbModel/User.cs`, `src/Config.DbModel/UserInvite.cs`, `src/Config.DbModel/PasswordReset.cs`, `src/Config.DbModel/Session.cs`
+
+**Produces (later tasks rely on):**
+
+```csharp
+namespace pote.Config.DbModel;
+public class User {
+    public Guid Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public string Role { get; set; } = UserRoles.User;   // "Admin" | "User"
+    public bool IsGuest { get; set; }
+    public bool Deleted { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? LastLoginUtc { get; set; }
+}
+public static class UserRoles { public const string Admin = "Admin"; public const string User = "User"; }
+
+public class UserInvite {
+    public Guid Id { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = UserRoles.User;
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime ExpiresUtc { get; set; }
+}
+public class PasswordReset {
+    public Guid Id { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public DateTime ExpiresUtc { get; set; }
+}
+public class Session {
+    public string Token { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime ExpiresUtc { get; set; }
+}
+```
+
+- [ ] Create the four files; build `dotnet build src/Config.DbModel/Config.DbModel.csproj`; commit.
+
+### Task 2: IUserDataAccess interface
+
+**Files:**
+- Create: `src/Config.DataProvider.Interfaces/IUserDataAccess.cs`
+
+**Produces:**
+
+```csharp
+namespace pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+/// <summary>Result of validating a session token: the session joined with its live user row.</summary>
+public class SessionUser {
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsGuest { get; set; }
+    public Guid UserId { get; set; }
+    public DateTime ExpiresUtc { get; set; }
+}
+
+public interface IUserDataAccess {
+    // Users
+    Task<int> CountUsers(CancellationToken ct);                       // all rows incl. soft-deleted
+    Task<List<User>> GetUsers(CancellationToken ct);                  // incl. soft-deleted
+    Task<User?> GetUserByUsername(string username, CancellationToken ct); // incl. soft-deleted
+    Task<User?> GetUserById(Guid id, CancellationToken ct);
+    Task InsertUser(User user, CancellationToken ct);                 // idempotent for guest: swallow duplicate-key when IsGuest
+    /// <summary>Set Deleted=1 unless user is the last active admin. Returns false if blocked.</summary>
+    Task<bool> SoftDeleteUser(Guid id, CancellationToken ct);
+    Task RestoreUser(Guid id, CancellationToken ct);
+    Task PermanentlyDeleteUser(Guid id, CancellationToken ct);        // only call on soft-deleted rows
+    Task HardDeleteGuest(CancellationToken ct);                       // deletes IsGuest row; FK cascades sessions
+    /// <summary>Change role unless demoting the last active admin. Returns false if blocked.</summary>
+    Task<bool> UpdateRole(Guid id, string role, CancellationToken ct);
+    Task UpdateLastLogin(Guid id, DateTime utc, CancellationToken ct);
+    /// <summary>Update hash only if current hash matches expectedOldHash (rehash race guard).</summary>
+    Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken ct);
+
+    // Invites
+    Task<List<UserInvite>> GetInvites(CancellationToken ct);
+    Task UpsertInvite(UserInvite invite, CancellationToken ct);       // replaces existing invite for same username
+    Task DeleteInvite(string username, CancellationToken ct);
+    /// <summary>Atomically consume (delete+return) an unexpired invite. Null if missing/expired.</summary>
+    Task<UserInvite?> ConsumeInvite(string token, CancellationToken ct);
+
+    // Password resets
+    Task UpsertReset(PasswordReset reset, CancellationToken ct);      // replaces existing reset for same user
+    Task<PasswordReset?> ConsumeReset(string token, CancellationToken ct);
+    Task DeleteResetsForUser(Guid userId, CancellationToken ct);
+
+    // Sessions
+    Task InsertSession(Session session, CancellationToken ct);
+    /// <summary>Join session→user; null when missing, expired, or user soft-deleted.</summary>
+    Task<SessionUser?> GetSessionUser(string token, CancellationToken ct);
+    Task DeleteSession(string token, CancellationToken ct);
+    Task DeleteSessionsForUser(Guid userId, CancellationToken ct);
+    Task DeleteOtherSessionsForUser(Guid userId, string keepToken, CancellationToken ct);
+
+    Task CleanupExpired(CancellationToken ct);                        // bounded batches
+}
+```
+
+- [ ] Create file; build interfaces project; commit.
+
+### Task 3: SQL CreateScripts
+
+**Files:**
+- Create: `src/Config.DataProvider.SqlServer/CreateScripts/15_Users.sql`, `16_UserInvites.sql`, `17_PasswordResets.sql`, `18_Sessions.sql`, `19_AlterAuditLog_AddUsernameAndAction.sql`
+- Modify: `src/Config.DataProvider.SqlServer/CreateScripts/13_AuditLog.sql` (add `Username NVARCHAR(100) NULL`, `Action NVARCHAR(50) NULL`)
+
+Schemas exactly per spec "Data model" section (CHECK constraints on Role; unique indexes: `Users.Username`, `UserInvites.Username`, `PasswordResets.UserId`; FKs `ON DELETE CASCADE` from PasswordResets/Sessions to Users; indexes on every ExpiresUtc; CI collation on username columns). Script 19 idempotent (`IF COL_LENGTH(...) IS NULL`) and backfills `Action = Content` for legacy rows (`WHERE [Action] IS NULL AND LEN([Content]) <= 50`).
+
+- [ ] Write scripts; commit. (No automated verification — scripts are deployed manually per repo convention.)
+
+### Task 4: SqlServer UserDataAccess (Dapper)
+
+**Files:**
+- Create: `src/Config.DataProvider.SqlServer/UserDataAccess.cs`
+
+**Consumes:** `SqlConnectionFactory` (existing), Task 2 interface.
+
+Key requirements (per spec Concurrency section):
+- `ConsumeInvite`/`ConsumeReset`: `DELETE ... OUTPUT DELETED.* WHERE Token=@token AND ExpiresUtc > GETUTCDATE()` — atomic single statement.
+- `SoftDeleteUser`: `UPDATE Users SET Deleted=1 WHERE Id=@id AND Deleted=0 AND (Role<>'Admin' OR EXISTS(SELECT 1 FROM Users u2 WHERE u2.Role='Admin' AND u2.Deleted=0 AND u2.Id<>@id))`; rowcount 1 → also delete sessions+resets for user (same transaction); return rowcount=1.
+- `UpdateRole`: same EXISTS-guard pattern for demotion from Admin.
+- `InsertUser` guest idempotency: `IF NOT EXISTS (SELECT 1 FROM Users) INSERT ...` inside try/catch treating error 2601/2627 as success when `IsGuest`.
+- `GetSessionUser`: `SELECT u.Username, u.Role, u.IsGuest, u.Id AS UserId, s.ExpiresUtc FROM Sessions s JOIN Users u ON u.Id=s.UserId WHERE s.Token=@token AND s.ExpiresUtc > GETUTCDATE() AND u.Deleted=0`.
+- `UpdatePasswordHash` with `expectedOldHash`: `WHERE Id=@id AND (@expectedOldHash IS NULL OR PasswordHash=@expectedOldHash)`.
+- `CleanupExpired`: `DELETE TOP (1000) FROM Sessions WHERE ExpiresUtc < GETUTCDATE()` (same for invites/resets).
+
+- [ ] Implement; build; commit.
+
+### Task 5: File provider stub + DI wiring + fail-fast
+
+**Files:**
+- Create: `src/Config.DataProvider.File/UserDataAccess.cs` (every method `throw new NotSupportedException("User login requires the SqlServer data provider.");` — expose `public const string NotSupportedMessage`)
+- Modify: `src/Config.Admin.Api/Program.cs` (register `IUserDataAccess` in both provider branches; default `dataProviderType` → `"SqlServer"`)
+- Modify: `src/Config.Api/Program.cs` (default `"SqlServer"` only — no user store needed there)
+
+Fail-fast (Program.cs, after `builder.Build()`, Local provider only): resolve `IUserDataAccess`, call `CountUsers`; catch `NotSupportedException` → log fatal + throw. (Folded into Task 8 startup wiring — here just registration + default flip.)
+
+- [ ] Implement; build both APIs; commit.
+
+### Task 6: Audit logging — Username + Action columns
+
+**Files:**
+- Modify: `src/Config.DataProvider.Interfaces/IAuditLogHandler.cs` — every method gains `string? username` and `string action` parameters; add `Task AuditLogUser(string entityId, string callerIp, string? username, string action, string content)`.
+- Modify: `src/Config.DataProvider.SqlServer/AuditLogHandler.cs` — write `Username`/`Action` columns; `EntityType="User"` for the new method.
+- Modify: `src/Config.DataProvider.File/AuditLogHandler.cs` (check existing shape first) — include username/action in the written content string.
+- Modify: `src/Config.Admin.Api/Helpers/AuditLogger.cs`:
+
+```csharp
+public static async Task AuditLog(this ControllerBase c, string id, string action,
+    Func<string, string, string?, string, string, Task> func, string content = "")
+{
+    var ip = c.Request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    var username = c.User.Identity?.IsAuthenticated == true ? c.User.Identity!.Name : null;
+    await func(id, ip, username, action, content);
+}
+```
+
+- Modify: all existing controllers' `AuditLog` call sites (signature ripple only).
+
+**Interfaces produced:** `IAuditLogHandler.AuditLogUser(entityId, callerIp, username, action, content)` — used by Task 9/10 for events `Login`, `LoginFailed`, `InviteCreated`, `InviteRevoked`, `ResetLinkCreated`, `PasswordChanged`, `RoleChanged`, `UserCreated`, `UserDeleted`, `UserRestored`, `UserPermanentlyDeleted`.
+
+- [ ] Implement; build solution; fix ripples; commit.
+
+### Task 7: Auth core — password policy, token generator, AuthService (TDD)
+
+**Files:**
+- Create: `src/Config.Admin.Api/Auth/PasswordPolicy.cs`, `src/Config.Admin.Api/Auth/TokenGenerator.cs`, `src/Config.Admin.Api/Auth/AuthService.cs`, `src/Config.Admin.Api/Auth/AuthSettings.cs`, `src/Config.Admin.Api/Auth/UsernameRules.cs`
+- Test: `src/Config.UnitTests/Auth/PasswordPolicyTests.cs`, `UsernameRulesTests.cs`, `AuthServiceTests.cs`
+- Modify: `src/Config.Admin.Api/Config.Admin.Api.csproj` (add `Microsoft.Extensions.Identity.Core`)
+
+**Produces:**
+
+```csharp
+public class AuthSettings { public int SessionLifetimeHours { get; set; } = 8; public int InviteLifetimeDays { get; set; } = 7; }
+
+public static class PasswordPolicy {
+    /// <summary>Null when valid, else human-readable reason. 16–128, lower+upper+digit+special.</summary>
+    public static string? Validate(string password);
+}
+public static class UsernameRules {
+    /// <summary>Trims; null+normalized out-param when valid. Rejects "guest" (case-insensitive), bad chars, bad length.</summary>
+    public static string? Validate(string raw, out string trimmed);
+    public const string GuestUsername = "guest";
+}
+public static class TokenGenerator { public static string NewToken(); } // 32 random bytes, base64url
+
+public class LoginResult { public string Token=""; public DateTime ExpiresUtc; public string Username=""; public string Role=""; public bool IsGuest; }
+
+public class AuthService {   // ctor: IUserDataAccess, IPasswordHasher<User>, AuthSettings, ILogger<AuthService>
+    Task<LoginResult?> Login(string username, string password, CancellationToken ct);       // null = uniform failure
+    Task<LoginResult?> Redeem(string token, string password, CancellationToken ct);         // invites + resets
+    Task<bool> ChangePassword(Guid userId, string current, string @new, string keepToken, CancellationToken ct);
+    Task<LoginResult> CreateFirstUser(string username, string password, CancellationToken ct); // guest path; role=Admin — throws InvalidOperationException on taken username
+    Task EnsureGuestSeeded(CancellationToken ct);   // CountUsers==0 → InsertUser(guest, hashed "guest", Role=Admin, IsGuest=true)
+}
+```
+
+AuthService behavior (all spec'd): Login does dummy-hash verify for unknown/deleted users; on success updates LastLoginUtc, hard-deletes guest when non-guest logs in, creates session; rehash-on-`SuccessRehashNeeded` via `UpdatePasswordHash(expectedOldHash: oldHash)`. Redeem: try `ConsumeInvite` → validate username still free → `InsertUser` (invite role); else `ConsumeReset` → user must exist non-deleted → update hash + `DeleteSessionsForUser`; both → auto-login result (which triggers guest deletion path). ChangePassword verifies current, validates policy, updates hash, `DeleteOtherSessionsForUser`. **Minimum-response-time lives in the controller, not here.**
+
+- [ ] Write failing tests (guest lifecycle: seed-on-empty, guest deleted on real login, not deleted on guest login; login unknown/wrong-password/soft-deleted → null; redemption: invite happy, invite username-taken, reset happy revokes sessions, expired/consumed → null; change password wrong-current → false; policy matrix; username matrix incl. `guest` reserved)
+- [ ] Run `dotnet test src/Config.UnitTests/Config.UnitTests.csproj --filter "FullyQualifiedName~Auth"` → all fail
+- [ ] Implement; tests green; commit.
+
+### Task 8: Provider seam, session auth handler, policies, bootstrap, rate limiting
+
+**Files:**
+- Create: `src/Config.Admin.Api/Auth/IAuthProviderSetup.cs`, `src/Config.Admin.Api/Auth/LocalAuthProviderSetup.cs`, `src/Config.Admin.Api/Auth/SessionAuthenticationHandler.cs`, `src/Config.Admin.Api/Auth/AuthPolicies.cs`
+- Modify: `src/Config.Admin.Api/Program.cs`, `src/Config.Admin.Api/appsettings.json` (`"Auth": { "Provider": "Local" }`)
+- Test: `src/Config.UnitTests/Auth/SessionAuthenticationHandlerTests.cs`
+
+**Produces:**
+
+```csharp
+public interface IAuthProviderSetup {
+    string Type { get; }                                  // "local"
+    void ConfigureServices(IServiceCollection services, IConfiguration config);
+    void ConfigureAuthentication(AuthenticationBuilder builder);
+    object ProviderMetadata { get; }                      // serialized by GET /api/auth/provider
+}
+public static class AuthPolicies {
+    public const string RealUser = "RealUser";   // authenticated && !guest claim
+    public const string AdminOnly = "AdminOnly"; // role claim == Admin
+    public const string GuestOnly = "GuestOnly"; // guest claim present
+    public const string GuestClaim = "guest";
+    public const string SchemeName = "LocalSession";
+}
+```
+
+`SessionAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>`: reads `Authorization: Bearer <token>`, calls `IUserDataAccess.GetSessionUser`, builds `ClaimsPrincipal` with `ClaimTypes.Name`, `ClaimTypes.Role`, `guest` claim (+ `userId` claim with the GUID). No token/expired/deleted → `AuthenticateResult.NoResult()/Fail`.
+
+Program.cs wiring: `AddAuthentication(SchemeName).AddScheme<...>`; `AddAuthorization` with the three policies + FallbackPolicy = RealUser (so unattributed endpoints default to real-user); rate limiter policy `"auth"` (fixed window per IP, 10/min, on login+redeem); startup: fail-fast check + `AuthService.EnsureGuestSeeded` + warning log while guest exists; `app.UseAuthentication(); app.UseAuthorization(); app.UseRateLimiter();`. Remove `ApiKeyValidation`/`ApiKeyAuthenticationFilter` registrations. Swagger: bearer security definition replacing X-API-Key.
+
+- [ ] TDD the handler (valid token → claims incl. role; guest claim only when IsGuest; missing/expired → fail); implement wiring; build; commit.
+
+### Task 9: AuthController
+
+**Files:**
+- Create: `src/Config.Admin.Api/Controllers/AuthController.cs`
+- Create (DTOs): `src/Config.Admin.Api.Model/RequestResponse/Auth/*` following existing Model project layout — `LoginRequest {Username, Password}`, `RedeemRequest {Token, Password}`, `ChangePasswordRequest {CurrentPassword, NewPassword}`, `LoginResponse {Token, ExpiresUtc, Username, Role, IsGuest}`, `ProviderResponse {Type}`
+- Test: `src/Config.UnitTests/Controllers/AuthControllerTests.cs`
+
+Endpoints per spec: `POST auth/login` (AllowAnonymous, rate-limited, min-500ms-on-failure via `Task.Delay` remainder, audit Login/LoginFailed, `Cache-Control: no-store`), `POST auth/redeem` (same anon/limits, generic 400), `POST auth/logout` (any authenticated incl. guest → `DeleteSession`), `POST auth/change-password` (RealUser policy), `GET auth/provider` (anon → active `IAuthProviderSetup.ProviderMetadata`). Route prefix: `[Route("api/auth")]` — **note** existing controllers use bare `[Route("[controller]")]`; match SPA client paths accordingly (use `api/auth` + update below).
+
+- [ ] TDD controller logic (login 401 shape uniform, no-store header set, logout deletes session, redeem 400 on null); implement; commit.
+
+### Task 10: UsersController
+
+**Files:**
+- Create: `src/Config.Admin.Api/Controllers/UsersController.cs`
+- Create DTOs: `UserListResponse { Users: List<UserInfo>, Invites: List<InviteInfo> }`, `UserInfo {Id, Username, Role, Deleted, IsGuest, CreatedUtc, LastLoginUtc}`, `InviteInfo {Username, Role, CreatedBy, ExpiresUtc}`, `CreateInviteRequest {Username, Role}`, `TokenResponse {Token, ExpiresUtc}`, `CreateUserRequest {Username, Password}`, `ChangeRoleRequest {Role}`
+- Test: `src/Config.UnitTests/Controllers/UsersControllerTests.cs`
+
+Endpoints per spec (AdminOnly unless noted): `GET api/users`; `POST api/users/invites` (validate username rules + not-existing/not-soft-deleted → 400 messages, `UpsertInvite`, audit); `DELETE api/users/invites/{username}`; `POST api/users/{username}/reset` (`UpsertReset`); `PUT api/users/{username}/role` (400 when `UpdateRole` returns false); `DELETE api/users/{username}` (`?permanent=` param; self-delete → 400; last-admin block → 400; permanent only when already deleted); `POST api/users/{username}/restore`; `POST api/users` (**GuestOnly**, `AuthService.CreateFirstUser`). All mutations audited with the acting username.
+
+- [ ] TDD (guest-only create enforced by policy attribute presence; last-admin 400 path; self-delete 400; invite→existing-user 400 vs soft-deleted "restore instead" message); implement; commit.
+
+### Task 11: Convert existing controllers to session auth
+
+**Files:**
+- Modify: `ApiKeysController.cs`, `ApplicationsController.cs`, `ConfigParseController.cs`, `DependencyGraphController.cs`, `EnvironmentsController.cs`, `SecretsController.cs`, `SettingsController.cs`, `ConfigurationsController.cs` — replace `[ApiKey]` with `[Authorize(Policy = AuthPolicies.RealUser)]`.
+- Modify: `src/Config.Auth/*` stays (Config.Api still uses it); only Admin API references dropped.
+
+- [ ] Sweep, build, run full test suite `dotnet test src/Config.UnitTests/Config.UnitTests.csproj`; commit.
+
+### Task 12: Frontend auth store + client seam
+
+**Files:**
+- Create: `src/Config.Admin.WebClient/src/lib/auth/session.svelte.ts` (auth store: `{token, expiresUtc, username, role, isGuest}`, localStorage persistence key `configservice.session`, `login/logout/load` functions, `$state` rune)
+- Modify: `src/lib/runtime-config.ts` (drop `apiKey` — remove validation + type field)
+- Modify: `src/lib/api/client.ts` (bearer header from store; on 401 → clear session + `goto('/login')`; skip redirect for the login/redeem calls themselves)
+- Modify: `static/config.json` (remove apiKey)
+- Test: extend `src/lib/api/client.test.ts`, create `src/lib/auth/session.test.ts`
+
+- [ ] TDD store + client changes (`npm test`); commit.
+
+### Task 13: Login, redeem, guest pages + layout guard
+
+**Files:**
+- Create: `src/routes/login/+page.svelte`, `src/routes/redeem/+page.svelte`, `src/routes/first-user/+page.svelte`
+- Modify: `src/routes/+layout.svelte` (guard: no session → `/login` except `/login`,`/redeem`; guest → forced to `/first-user`; hide nav for guest), `src/app.html` (`<meta name="referrer" content="same-origin">`)
+- Create: `src/lib/api/authApi.ts` (login/redeem/logout/changePassword/provider wrappers using `postJson`/`getJson`)
+
+Redeem page: token from `location.hash` (`#token=...`), `history.replaceState` immediately, password ×2 with client-side policy check mirroring `PasswordPolicy`, submit → store session → `goto('/')`.
+
+- [ ] Implement; `npm run check`; manual smoke via dev server; commit.
+
+### Task 14: Users admin page + header menu
+
+**Files:**
+- Create: `src/routes/users/+page.svelte`, `src/lib/api/usersApi.ts`
+- Modify: header/nav component (add Users link for role Admin, change-password dialog, logout button)
+
+Users page per spec: table (username, role, last login, created, deleted badge), "show deleted" toggle, invite dialog (username+role → copyable `${location.origin}/redeem#token=...`), revoke invite, reset link dialog (copyable), role select (with last-admin 400 surfaced), soft delete (confirm), restore, permanent delete (confirm, only on deleted).
+
+- [ ] Implement; `npm run check`; commit.
+
+### Task 15: Regenerate API types + e2e tests
+
+**Files:**
+- Regenerate: `src/lib/api/generated.d.ts` (`npm run gen:api` with Admin API running)
+- Create: `e2e/auth.spec.ts` (mocked routes per existing `e2e/mocks.ts` pattern): login happy path → main page; guest login → forced first-user screen → create → lands authenticated; redeem flow (`/redeem#token=x` mock 200 → home)
+- Modify: `e2e/mocks.ts` (auth route mocks), `e2e/smoke.spec.ts` (inject session before navigation)
+
+- [ ] `npm run test:e2e` green locally; commit.
+
+### Task 16: Docs + rollout
+
+**Files:**
+- Modify: `README.md` (setup flow: SQL scripts, guest/guest claim, invites, reset; breaking-changes section; "adding an auth provider" extension section)
+- Modify: `CLAUDE.md` (SQL Server primary provider, auth architecture summary, new test locations)
+
+- [ ] Update; final full test pass (`dotnet test` + `npm test` + `npm run build`); commit.
+
+## Self-Review Notes
+
+- Spec coverage checked section-by-section: data model (T1–T4), provider seam (T8), endpoints (T9–T11), bootstrap/config (T5, T7, T8), frontend (T12–T15), audit (T6, T9, T10), testing (T7–T10, T12, T15), rollout (T16). Concurrency requirements live in T4 SQL patterns + T7 service semantics.
+- Type consistency: `IUserDataAccess` signatures in T2 are the single source; T4/T7/T8 consume them verbatim.
+- Deviation from writing-plans skill granularity: steps are task-level with TDD checkpoints rather than 2-minute micro-steps — executor is the planning session itself, in-session, immediately after planning.

--- a/docs/plans/2026-08-04-admin-login-pr-review.md
+++ b/docs/plans/2026-08-04-admin-login-pr-review.md
@@ -1,0 +1,47 @@
+# Admin login — external PR review triage
+
+Date: 2026-08-04. Reviewer: ChatGPT (gpt-5.6-sol) via OpenAI API, reviewing the full PR #203
+diff plus description. 8 findings: 2 blocker, 6 should-fix.
+
+## Accepted (fixed in the PR)
+
+1. **[blocker] Last-admin rail not concurrency-safe under READ COMMITTED** — two concurrent
+   demotions/deletes could each observe the other admin and both succeed. Fixed:
+   `SoftDeleteUser` and `UpdateRole` now serialize on a transaction-scoped
+   `sp_getapplock` (`ConfigService.AdminRail`) before the guarded UPDATE.
+2. **[blocker, partial] Concurrent password changes could both report success** — fixed:
+   `ChangePassword` now uses a guarded update (`WHERE PasswordHash = @expectedOldHash`,
+   rowcount-checked); the loser of the race gets `false`. See Rejected #1 for the rest of
+   this finding.
+3. **Audit rows on anonymous endpoints had `Username = NULL`** — fixed: the audit helper
+   accepts an explicit acting username; login/redeem stamp the just-authenticated user.
+4. **Invite redemption only audited `Login`; reset redemption missed `PasswordChanged`;
+   invite revocation used `Guid.Empty`** — fixed: `LoginResult.Redemption` drives extra
+   `UserCreated`/`PasswordChanged` audit events; `DeleteInvite` returns the deleted
+   invite's Id (`OUTPUT DELETED`) for the audit row.
+5. **Audit failure turned completed operations into API errors** — fixed: audit writes are
+   wrapped; a failed audit is logged (Serilog) but never changes the API result.
+6. **`Problem(ex.Message)` leaked SQL/provider details** — fixed in the new
+   auth/user controllers (generic messages, full exception logged server-side). The same
+   pattern in pre-existing controllers is untouched: changing repo-wide error behavior is
+   out of scope for this feature.
+7. **Token columns inherited case-insensitive collation** — fixed: `Token` columns in
+   `16`–`18` are `Latin1_General_100_BIN2` (opaque-token semantics). No alter script
+   needed — these tables are new in this PR.
+8. **Role CHECK constraints case-insensitive (`'admin'` would pass)** — fixed: `Role`
+   columns in `15`/`16` are `Latin1_General_100_BIN2`, so only canonical values pass.
+9. **Frontend/backend password policy divergence (Unicode vs ASCII classes)** — fixed:
+   backend now uses explicit ASCII checks (`IsAsciiLetterLower/Upper`, `IsAsciiDigit`;
+   special = anything else), matching the client regexes exactly.
+
+## Rejected / deferred (with reasons)
+
+1. **Full unit-of-work refactor (one connection/transaction per workflow: redeem,
+   first-user, guest deletion + session issuance)** — Deferred. The remaining windows are
+   narrow (e.g. invite consumed but user insert fails; guest finishing a create while a
+   concurrent first login deletes guest) and low-impact for an admin tool with a handful
+   of users. The single-use token consume, the admin rail, and the password-change guard —
+   the invariants that actually protect security — are now atomic. A UoW abstraction over
+   `IUserDataAccess` is honest future work if the tool grows multi-tenant traffic.
+2. **Concurrent SQL integration tests** — Rejected for this feature, consistent with the
+   spec-review triage: no SQL Server integration-test infrastructure in the repo.

--- a/docs/plans/2026-08-04-admin-login-spec-review.md
+++ b/docs/plans/2026-08-04-admin-login-spec-review.md
@@ -1,0 +1,75 @@
+# Admin login — external spec review triage
+
+Date: 2026-08-04. Reviewer: ChatGPT (gpt-5.6-sol) via OpenAI API. 24 findings:
+4 blocker, 19 should-fix, 1 nitpick. Full reviewer output retained in the session; this file
+records the disposition of each finding.
+
+## Accepted (spec updated)
+
+1. **[blocker] Invite role not persisted** — `UserTokens` split into `UserInvites`
+   (username, role, createdBy) and `PasswordResets` (UserId FK); invites carry role in the DB.
+2. **[blocker] Claims contract missing role** — canonical `role` claim added; login response
+   and SPA auth store include `role`; session validation joins Users so claims always
+   reflect the current row; OIDC role-mapping declared the provider's responsibility.
+3. **[blocker] Non-null `Action` migration fails on existing rows** — `Action` is nullable;
+   idempotent alter script backfills it from legacy `Content`; all new writes set it.
+4. **Reset/change-password leaves sessions valid** — reset redemption revokes all prior
+   sessions; change-password revokes other sessions; both transactional.
+5. **Transactions/locking unspecified** — new "Concurrency & atomicity" section: atomic
+   token consumption (affected-row check), in-transaction last-admin invariant, idempotent
+   race-safe guest bootstrap, transactional password change.
+6. **Reset authorization contradiction (any user vs admin-only)** — resolved to admin-only
+   (Decision 3 fixed); ordinary users only change their own password. The contradiction was
+   a leftover from before roles existed.
+7. **Sessions/resets keyed by mutable username** — now keyed by immutable `UserId` with
+   `ON DELETE CASCADE` FKs; invites remain username-keyed by necessity (no user row yet).
+8. **Missing DB-enforced invariants** — NOT NULL, CHECK constraints on Role, explicit unique
+   indexes (username; one active invite per username; one active reset per user), expiry
+   indexes.
+9. **Collation not guaranteed CI** — explicit `Latin1_General_100_CI_AS` on username columns
+   instead of relying on server defaults.
+10. **Route-breaking username characters** — charset restricted to letters, digits, `.-_@`.
+11. **Role changes don't affect live sessions** — solved structurally: validation joins the
+    user row per request, so demotion/soft-delete apply on the next request.
+12. **Reset token leaks via query string** — redeem links use the URL fragment
+    (`#token=...`), stripped with `history.replaceState`; restrictive `Referrer-Policy`.
+13. **No cache/log hygiene for token responses** — `Cache-Control: no-store` on auth
+    responses; tokens/passwords/Authorization never logged.
+14. **500 ms sleep + no rate limit = resource exhaustion** — per-IP rate limiting on
+    login/redeem (ASP.NET Core rate limiter); minimum-total-response-time instead of an
+    unconditional sleep.
+15. **Timing-based username enumeration** — dummy hash verification for unknown users;
+    password length capped (128) and checked before hashing.
+16. **Failed-login audit unbounded** — attempted username truncated to 100 chars; write
+    volume bounded by the login rate limiter; forwarded-IP headers not trusted (unchanged
+    existing behavior: direct connection IP).
+17. **Cleanup unbounded / missing indexes** — bounded-batch deletes (`DELETE TOP (n)`),
+    expiry indexes, expiry authoritative at validation regardless of cleanup.
+18. **Audit `EntityId` undefined for invites / failed logins** — invites get a stable `Id`
+    GUID used as EntityId; failed logins use `Guid.Empty` + attempted username in Content.
+19. **Multi-instance bootstrap race** — idempotent insert; duplicate-key loss = success.
+20. **[nitpick] Rehash-on-verify** — adopted, guarded against concurrent password change.
+
+## Rejected (with reasons)
+
+1. **[blocker] Replace guest/guest with a per-install random bootstrap secret / localhost
+   setup mode** — Rejected as a redesign: the well-known guest/guest bootstrap is an explicit
+   product decision (developer requirement, recorded with its trade-offs in ADR-0004). The
+   reviewer's severity is understood; mitigations adopted instead: startup warning while
+   guest exists, "claim immediately" rollout instruction, and guest's capability being
+   limited to creating a user. Revisit if the project's threat model changes (e.g. instances
+   exposed to untrusted networks at first boot).
+2. **Force a password reset on restore (or block restore-with-old-hash)** — Rejected:
+   restore-with-old-credentials is the developer-approved semantic; the admin performing the
+   restore decides whether to also hand over a reset link. Sessions/tokens were already
+   revoked at soft-delete time, so nothing stale survives restore.
+3. **SQL Server integration tests (containerized) for migrations/races/collation** —
+   Rejected for this feature: the repo has no integration-test infrastructure and standing
+   one up is its own project. Recorded as accepted risk; the concurrency-sensitive SQL uses
+   affected-row patterns and is hand-reviewed. Reasonable future work.
+4. **Unicode normalization (NFC/NFKC) of usernames** — Rejected as overkill: the adopted
+   charset restriction (letters, digits, `.-_@`) plus explicit CI collation removes the
+   attack surface the normalization advice targets.
+5. **Audit retention/rotation policy** — Rejected as out of scope: consistent with the
+   existing AuditLog table, which has never had retention. Unchanged behavior, not a
+   regression introduced by this feature.

--- a/src/Config.Admin.Api.Model/RequestResponse/AuthModels.cs
+++ b/src/Config.Admin.Api.Model/RequestResponse/AuthModels.cs
@@ -1,0 +1,81 @@
+namespace pote.Config.Admin.Api.Model.RequestResponse;
+
+public class LoginRequest
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public class RedeemRequest
+{
+    public string Token { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public class ChangePasswordRequest
+{
+    public string CurrentPassword { get; set; } = string.Empty;
+    public string NewPassword { get; set; } = string.Empty;
+}
+
+public class LoginResponse
+{
+    public string Token { get; set; } = string.Empty;
+    public DateTime ExpiresUtc { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsGuest { get; set; }
+}
+
+public class ProviderResponse
+{
+    public string Type { get; set; } = string.Empty;
+}
+
+public class UserInfo
+{
+    public Guid Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool Deleted { get; set; }
+    public bool IsGuest { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? LastLoginUtc { get; set; }
+}
+
+public class InviteInfo
+{
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime ExpiresUtc { get; set; }
+}
+
+public class UserListResponse
+{
+    public List<UserInfo> Users { get; set; } = new();
+    public List<InviteInfo> Invites { get; set; } = new();
+}
+
+public class CreateInviteRequest
+{
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+}
+
+public class TokenResponse
+{
+    public string Token { get; set; } = string.Empty;
+    public DateTime ExpiresUtc { get; set; }
+}
+
+public class CreateUserRequest
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public class ChangeRoleRequest
+{
+    public string Role { get; set; } = string.Empty;
+}

--- a/src/Config.Admin.Api/Auth/AuthPolicies.cs
+++ b/src/Config.Admin.Api/Auth/AuthPolicies.cs
@@ -1,0 +1,20 @@
+namespace pote.Config.Admin.Api.Auth;
+
+/// <summary>
+/// The provider-agnostic claims contract: authorization is built exclusively on
+/// name, role, and the guest claim (which only the Local provider ever issues).
+/// </summary>
+public static class AuthPolicies
+{
+    public const string SchemeName = "LocalSession";
+
+    /// <summary>Authenticated, not guest. The fallback policy for all endpoints.</summary>
+    public const string RealUser = "RealUser";
+    /// <summary>Role claim == Admin (user management).</summary>
+    public const string AdminOnly = "AdminOnly";
+    /// <summary>Guest claim present (only the create-first-user endpoint).</summary>
+    public const string GuestOnly = "GuestOnly";
+
+    public const string GuestClaim = "guest";
+    public const string UserIdClaim = "userId";
+}

--- a/src/Config.Admin.Api/Auth/AuthService.cs
+++ b/src/Config.Admin.Api/Auth/AuthService.cs
@@ -1,0 +1,212 @@
+using Microsoft.AspNetCore.Identity;
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.Admin.Api.Auth;
+
+public class LoginResult
+{
+    public string Token { get; set; } = string.Empty;
+    public DateTime ExpiresUtc { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsGuest { get; set; }
+}
+
+/// <summary>
+/// Core of the Local auth provider: credential verification, session issuance,
+/// invite/reset redemption, and the guest bootstrap lifecycle.
+/// </summary>
+public class AuthService
+{
+    private readonly IUserDataAccess _users;
+    private readonly IPasswordHasher<User> _hasher;
+    private readonly AuthSettings _settings;
+    private readonly ILogger<AuthService> _logger;
+
+    // A fixed hash used to burn comparable CPU time for unknown usernames so
+    // response timing does not reveal whether a username exists.
+    private static readonly User DummyUser = new() { Username = "dummy" };
+    private readonly string _dummyHash;
+
+    public AuthService(IUserDataAccess users, IPasswordHasher<User> hasher, AuthSettings settings, ILogger<AuthService> logger)
+    {
+        _users = users;
+        _hasher = hasher;
+        _settings = settings;
+        _logger = logger;
+        _dummyHash = _hasher.HashPassword(DummyUser, TokenGenerator.NewToken());
+    }
+
+    public async Task<LoginResult?> Login(string username, string password, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(password) || password.Length > PasswordPolicy.MaxLength)
+            return null;
+
+        var user = await _users.GetUserByUsername(username?.Trim() ?? string.Empty, cancellationToken);
+        if (user == null || user.Deleted)
+        {
+            _hasher.VerifyHashedPassword(DummyUser, _dummyHash, password);
+            return null;
+        }
+
+        var verification = _hasher.VerifyHashedPassword(user, user.PasswordHash, password);
+        if (verification == PasswordVerificationResult.Failed)
+            return null;
+
+        if (verification == PasswordVerificationResult.SuccessRehashNeeded)
+        {
+            // Guarded by the old hash so a concurrent password change wins.
+            var newHash = _hasher.HashPassword(user, password);
+            await _users.UpdatePasswordHash(user.Id, newHash, user.PasswordHash, cancellationToken);
+        }
+
+        await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
+        await _users.CleanupExpired(cancellationToken);
+        return await CreateSession(user, cancellationToken);
+    }
+
+    public async Task<LoginResult?> Redeem(string token, string password, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+        // Validate the password before consuming the single-use token, so a
+        // rejected password does not burn the link.
+        if (PasswordPolicy.Validate(password) != null)
+            return null;
+
+        var invite = await _users.ConsumeInvite(token, cancellationToken);
+        if (invite != null)
+            return await RedeemInvite(invite, password, cancellationToken);
+
+        var reset = await _users.ConsumeReset(token, cancellationToken);
+        if (reset != null)
+            return await RedeemReset(reset, password, cancellationToken);
+
+        return null;
+    }
+
+    private async Task<LoginResult?> RedeemInvite(UserInvite invite, string password, CancellationToken cancellationToken)
+    {
+        var existing = await _users.GetUserByUsername(invite.Username, cancellationToken);
+        if (existing != null)
+        {
+            _logger.LogWarning("Invite for {Username} redeemed but the username is taken", invite.Username);
+            return null;
+        }
+
+        var user = new User
+        {
+            Username = invite.Username,
+            Role = invite.Role,
+            IsGuest = false,
+            CreatedUtc = DateTime.UtcNow
+        };
+        user.PasswordHash = _hasher.HashPassword(user, password);
+        await _users.InsertUser(user, cancellationToken);
+        await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
+        return await CreateSession(user, cancellationToken);
+    }
+
+    private async Task<LoginResult?> RedeemReset(PasswordReset reset, string password, CancellationToken cancellationToken)
+    {
+        var user = await _users.GetUserById(reset.UserId, cancellationToken);
+        if (user == null || user.Deleted || user.IsGuest)
+            return null;
+
+        var newHash = _hasher.HashPassword(user, password);
+        await _users.UpdatePasswordHash(user.Id, newHash, null, cancellationToken);
+        // A reset is typically used after compromise: every prior session dies.
+        await _users.DeleteSessionsForUser(user.Id, cancellationToken);
+        await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
+        return await CreateSession(user, cancellationToken);
+    }
+
+    public async Task<bool> ChangePassword(Guid userId, string currentPassword, string newPassword, string keepToken, CancellationToken cancellationToken)
+    {
+        if (PasswordPolicy.Validate(newPassword) != null)
+            return false;
+
+        var user = await _users.GetUserById(userId, cancellationToken);
+        if (user == null || user.Deleted || user.IsGuest)
+            return false;
+
+        if (_hasher.VerifyHashedPassword(user, user.PasswordHash, currentPassword) == PasswordVerificationResult.Failed)
+            return false;
+
+        var newHash = _hasher.HashPassword(user, newPassword);
+        await _users.UpdatePasswordHash(user.Id, newHash, null, cancellationToken);
+        await _users.DeleteOtherSessionsForUser(user.Id, keepToken, cancellationToken);
+        return true;
+    }
+
+    /// <summary>Guest-only path: directly create the first Admin and log them in.</summary>
+    public async Task<LoginResult> CreateFirstUser(string username, string password, CancellationToken cancellationToken)
+    {
+        var usernameError = UsernameRules.Validate(username, out var trimmed);
+        if (usernameError != null)
+            throw new InvalidOperationException(usernameError);
+        var passwordError = PasswordPolicy.Validate(password);
+        if (passwordError != null)
+            throw new InvalidOperationException(passwordError);
+
+        var existing = await _users.GetUserByUsername(trimmed, cancellationToken);
+        if (existing != null)
+            throw new InvalidOperationException(existing.Deleted
+                ? "That username belongs to a deleted user. Restore it instead."
+                : "That username is already taken.");
+
+        var user = new User
+        {
+            Username = trimmed,
+            Role = UserRoles.Admin,
+            IsGuest = false,
+            CreatedUtc = DateTime.UtcNow
+        };
+        user.PasswordHash = _hasher.HashPassword(user, password);
+        await _users.InsertUser(user, cancellationToken);
+        await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
+        // The auto-login is the first real login: guest dies here.
+        return (await CreateSession(user, cancellationToken))!;
+    }
+
+    /// <summary>Empty user store ⇒ (re)seed guest/guest. Idempotent and race-safe (see InsertUser).</summary>
+    public async Task EnsureGuestSeeded(CancellationToken cancellationToken)
+    {
+        if (await _users.CountUsers(cancellationToken) > 0)
+            return;
+        var guest = new User
+        {
+            Username = UsernameRules.GuestUsername,
+            Role = UserRoles.Admin,
+            IsGuest = true,
+            CreatedUtc = DateTime.UtcNow
+        };
+        guest.PasswordHash = _hasher.HashPassword(guest, UsernameRules.GuestUsername);
+        await _users.InsertUser(guest, cancellationToken);
+        _logger.LogWarning("User store was empty: seeded the guest/guest bootstrap user. Log in as guest and create a real user to claim this instance.");
+    }
+
+    private async Task<LoginResult?> CreateSession(User user, CancellationToken cancellationToken)
+    {
+        if (!user.IsGuest)
+            await _users.HardDeleteGuest(cancellationToken);
+
+        var session = new Session
+        {
+            Token = TokenGenerator.NewToken(),
+            UserId = user.Id,
+            CreatedUtc = DateTime.UtcNow,
+            ExpiresUtc = DateTime.UtcNow.AddHours(_settings.SessionLifetimeHours)
+        };
+        await _users.InsertSession(session, cancellationToken);
+        return new LoginResult
+        {
+            Token = session.Token,
+            ExpiresUtc = session.ExpiresUtc,
+            Username = user.Username,
+            Role = user.Role,
+            IsGuest = user.IsGuest
+        };
+    }
+}

--- a/src/Config.Admin.Api/Auth/AuthService.cs
+++ b/src/Config.Admin.Api/Auth/AuthService.cs
@@ -12,6 +12,8 @@ public class LoginResult
     public string Username { get; set; } = string.Empty;
     public string Role { get; set; } = string.Empty;
     public bool IsGuest { get; set; }
+    /// <summary>Set when the login came from redeeming a token: "invite" or "reset". Drives audit events.</summary>
+    public string? Redemption { get; set; }
 }
 
 /// <summary>
@@ -58,8 +60,8 @@ public class AuthService
         if (verification == PasswordVerificationResult.SuccessRehashNeeded)
         {
             // Guarded by the old hash so a concurrent password change wins.
-            var newHash = _hasher.HashPassword(user, password);
-            await _users.UpdatePasswordHash(user.Id, newHash, user.PasswordHash, cancellationToken);
+            var rehash = _hasher.HashPassword(user, password);
+            _ = await _users.UpdatePasswordHash(user.Id, rehash, user.PasswordHash, cancellationToken);
         }
 
         await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
@@ -106,7 +108,9 @@ public class AuthService
         user.PasswordHash = _hasher.HashPassword(user, password);
         await _users.InsertUser(user, cancellationToken);
         await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
-        return await CreateSession(user, cancellationToken);
+        var result = await CreateSession(user, cancellationToken);
+        if (result != null) result.Redemption = "invite";
+        return result;
     }
 
     private async Task<LoginResult?> RedeemReset(PasswordReset reset, string password, CancellationToken cancellationToken)
@@ -120,7 +124,9 @@ public class AuthService
         // A reset is typically used after compromise: every prior session dies.
         await _users.DeleteSessionsForUser(user.Id, cancellationToken);
         await _users.UpdateLastLogin(user.Id, DateTime.UtcNow, cancellationToken);
-        return await CreateSession(user, cancellationToken);
+        var result = await CreateSession(user, cancellationToken);
+        if (result != null) result.Redemption = "reset";
+        return result;
     }
 
     public async Task<bool> ChangePassword(Guid userId, string currentPassword, string newPassword, string keepToken, CancellationToken cancellationToken)
@@ -136,7 +142,10 @@ public class AuthService
             return false;
 
         var newHash = _hasher.HashPassword(user, newPassword);
-        await _users.UpdatePasswordHash(user.Id, newHash, null, cancellationToken);
+        // Guarded by the current hash: of two concurrent changes only one wins,
+        // instead of both reporting success.
+        if (!await _users.UpdatePasswordHash(user.Id, newHash, user.PasswordHash, cancellationToken))
+            return false;
         await _users.DeleteOtherSessionsForUser(user.Id, keepToken, cancellationToken);
         return true;
     }

--- a/src/Config.Admin.Api/Auth/AuthService.cs
+++ b/src/Config.Admin.Api/Auth/AuthService.cs
@@ -8,6 +8,7 @@ public class LoginResult
 {
     public string Token { get; set; } = string.Empty;
     public DateTime ExpiresUtc { get; set; }
+    public Guid UserId { get; set; }
     public string Username { get; set; } = string.Empty;
     public string Role { get; set; } = string.Empty;
     public bool IsGuest { get; set; }
@@ -204,6 +205,7 @@ public class AuthService
         {
             Token = session.Token,
             ExpiresUtc = session.ExpiresUtc,
+            UserId = user.Id,
             Username = user.Username,
             Role = user.Role,
             IsGuest = user.IsGuest

--- a/src/Config.Admin.Api/Auth/AuthSettings.cs
+++ b/src/Config.Admin.Api/Auth/AuthSettings.cs
@@ -1,0 +1,10 @@
+namespace pote.Config.Admin.Api.Auth;
+
+public class AuthSettings
+{
+    /// <summary>Active auth provider. Only "Local" is implemented.</summary>
+    public string Provider { get; set; } = "Local";
+    public int SessionLifetimeHours { get; set; } = 8;
+    /// <summary>Lifetime for invite links and reset links.</summary>
+    public int InviteLifetimeDays { get; set; } = 7;
+}

--- a/src/Config.Admin.Api/Auth/IAuthProviderSetup.cs
+++ b/src/Config.Admin.Api/Auth/IAuthProviderSetup.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace pote.Config.Admin.Api.Auth;
+
+/// <summary>
+/// Registration seam for pluggable auth providers (ADR-0002). A provider
+/// contributes its services and its authentication handler; everything outside
+/// the provider authorizes on claims only. Add a provider by implementing this
+/// interface and registering it in Program.cs for its Auth:Provider value.
+/// </summary>
+public interface IAuthProviderSetup
+{
+    /// <summary>Value matched against the Auth:Provider config setting (e.g. "Local").</summary>
+    string Type { get; }
+
+    void ConfigureServices(IServiceCollection services, IConfiguration configuration);
+
+    /// <summary>Register the authentication scheme(s) that turn requests into claims.</summary>
+    void ConfigureAuthentication(AuthenticationBuilder builder);
+
+    /// <summary>Anonymous metadata served by GET api/auth/provider so the SPA can adapt its login UI.</summary>
+    object ProviderMetadata { get; }
+}

--- a/src/Config.Admin.Api/Auth/LocalAuthProviderSetup.cs
+++ b/src/Config.Admin.Api/Auth/LocalAuthProviderSetup.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using pote.Config.DbModel;
+
+namespace pote.Config.Admin.Api.Auth;
+
+/// <summary>
+/// The Local (database users) auth provider: session-token authentication,
+/// AuthService, guest bootstrap. A future Oidc provider would instead register
+/// JwtBearer validation against an external authority and no local services.
+/// </summary>
+public class LocalAuthProviderSetup : IAuthProviderSetup
+{
+    public string Type => "Local";
+
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<IPasswordHasher<User>, PasswordHasher<User>>();
+        services.AddScoped<AuthService>();
+    }
+
+    public void ConfigureAuthentication(AuthenticationBuilder builder)
+    {
+        builder.AddScheme<AuthenticationSchemeOptions, SessionAuthenticationHandler>(AuthPolicies.SchemeName, null);
+    }
+
+    public object ProviderMetadata => new { type = "local" };
+}

--- a/src/Config.Admin.Api/Auth/PasswordPolicy.cs
+++ b/src/Config.Admin.Api/Auth/PasswordPolicy.cs
@@ -12,13 +12,15 @@ public static class PasswordPolicy
             return $"Password must be at least {MinLength} characters.";
         if (password.Length > MaxLength)
             return $"Password must be at most {MaxLength} characters.";
-        if (!password.Any(char.IsLower))
+        // Explicit ASCII classes to stay in lockstep with the SPA's regex checks
+        // (Unicode-aware char.IsLower etc. would accept passwords the client rejects).
+        if (!password.Any(char.IsAsciiLetterLower))
             return "Password must contain a lowercase letter.";
-        if (!password.Any(char.IsUpper))
+        if (!password.Any(char.IsAsciiLetterUpper))
             return "Password must contain an uppercase letter.";
-        if (!password.Any(char.IsDigit))
+        if (!password.Any(char.IsAsciiDigit))
             return "Password must contain a digit.";
-        if (password.All(char.IsLetterOrDigit))
+        if (password.All(char.IsAsciiLetterOrDigit))
             return "Password must contain a special character.";
         return null;
     }

--- a/src/Config.Admin.Api/Auth/PasswordPolicy.cs
+++ b/src/Config.Admin.Api/Auth/PasswordPolicy.cs
@@ -1,0 +1,25 @@
+namespace pote.Config.Admin.Api.Auth;
+
+public static class PasswordPolicy
+{
+    public const int MinLength = 16;
+    public const int MaxLength = 128;
+
+    /// <summary>Null when valid, otherwise a human-readable reason.</summary>
+    public static string? Validate(string password)
+    {
+        if (string.IsNullOrEmpty(password) || password.Length < MinLength)
+            return $"Password must be at least {MinLength} characters.";
+        if (password.Length > MaxLength)
+            return $"Password must be at most {MaxLength} characters.";
+        if (!password.Any(char.IsLower))
+            return "Password must contain a lowercase letter.";
+        if (!password.Any(char.IsUpper))
+            return "Password must contain an uppercase letter.";
+        if (!password.Any(char.IsDigit))
+            return "Password must contain a digit.";
+        if (password.All(char.IsLetterOrDigit))
+            return "Password must contain a special character.";
+        return null;
+    }
+}

--- a/src/Config.Admin.Api/Auth/SessionAuthenticationHandler.cs
+++ b/src/Config.Admin.Api/Auth/SessionAuthenticationHandler.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using pote.Config.DataProvider.Interfaces;
+
+namespace pote.Config.Admin.Api.Auth;
+
+/// <summary>
+/// Validates opaque bearer tokens against the Sessions table (joined to the live
+/// user row, so role changes and deletions take effect on the next request).
+/// </summary>
+public class SessionAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    private readonly IUserDataAccess _users;
+
+    public SessionAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger, UrlEncoder encoder, IUserDataAccess users)
+        : base(options, logger, encoder)
+    {
+        _users = users;
+    }
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var header = Request.Headers.Authorization.ToString();
+        if (string.IsNullOrEmpty(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return AuthenticateResult.NoResult();
+
+        var token = header["Bearer ".Length..].Trim();
+        if (token.Length == 0)
+            return AuthenticateResult.NoResult();
+
+        var sessionUser = await _users.GetSessionUser(token, Context.RequestAborted);
+        if (sessionUser == null)
+            return AuthenticateResult.Fail("Invalid or expired session");
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, sessionUser.Username),
+            new(ClaimTypes.Role, sessionUser.Role),
+            new(AuthPolicies.UserIdClaim, sessionUser.UserId.ToString()),
+            new("sessionToken", token)
+        };
+        if (sessionUser.IsGuest)
+            claims.Add(new Claim(AuthPolicies.GuestClaim, "true"));
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name, ClaimTypes.Name, ClaimTypes.Role);
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);
+        return AuthenticateResult.Success(ticket);
+    }
+}

--- a/src/Config.Admin.Api/Auth/TokenGenerator.cs
+++ b/src/Config.Admin.Api/Auth/TokenGenerator.cs
@@ -1,0 +1,13 @@
+using System.Security.Cryptography;
+
+namespace pote.Config.Admin.Api.Auth;
+
+public static class TokenGenerator
+{
+    /// <summary>256-bit random token, url-safe base64 without padding.</summary>
+    public static string NewToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/src/Config.Admin.Api/Auth/UsernameRules.cs
+++ b/src/Config.Admin.Api/Auth/UsernameRules.cs
@@ -1,0 +1,26 @@
+namespace pote.Config.Admin.Api.Auth;
+
+public static class UsernameRules
+{
+    public const string GuestUsername = "guest";
+    public const int MaxLength = 100;
+
+    /// <summary>
+    /// Null (with the trimmed username in the out parameter) when valid,
+    /// otherwise a human-readable reason. Allowed characters: letters, digits, . - _ @
+    /// — conservative on purpose: usernames appear in route segments and logs.
+    /// </summary>
+    public static string? Validate(string raw, out string trimmed)
+    {
+        trimmed = (raw ?? string.Empty).Trim();
+        if (trimmed.Length == 0)
+            return "Username is required.";
+        if (trimmed.Length > MaxLength)
+            return $"Username must be at most {MaxLength} characters.";
+        if (!trimmed.All(c => char.IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_' or '@'))
+            return "Username may only contain letters, digits, and . - _ @";
+        if (trimmed.Equals(GuestUsername, StringComparison.OrdinalIgnoreCase))
+            return "That username is reserved.";
+        return null;
+    }
+}

--- a/src/Config.Admin.Api/Config.Admin.Api.csproj
+++ b/src/Config.Admin.Api/Config.Admin.Api.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Df.ServiceControllerExtensions" Version="1.0.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.10" />
     <PackageReference Include="newtonsoft.json" Version="13.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/Config.Admin.Api/Controllers/ApiKeysController.cs
+++ b/src/Config.Admin.Api/Controllers/ApiKeysController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using pote.Config.Admin.Api.Model.RequestResponse;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.DataProvider.Interfaces;
 using pote.Config.Admin.Api.Helpers;
 
@@ -8,7 +9,7 @@ namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class ApiKeysController : ControllerBase
 {
     private readonly ILogger<ApiKeysController> _logger;

--- a/src/Config.Admin.Api/Controllers/ApplicationsController.cs
+++ b/src/Config.Admin.Api/Controllers/ApplicationsController.cs
@@ -1,17 +1,18 @@
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using pote.Config.Admin.Api.Helpers;
 using pote.Config.Admin.Api.Mappers;
 using pote.Config.Admin.Api.Model.RequestResponse;
 using pote.Config.Admin.Api.Services;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.DataProvider.Interfaces;
 
 namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class ApplicationsController : ControllerBase
 {
     private readonly ILogger<ApplicationsController> _logger;

--- a/src/Config.Admin.Api/Controllers/AuthController.cs
+++ b/src/Config.Admin.Api/Controllers/AuthController.cs
@@ -1,0 +1,132 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using pote.Config.Admin.Api.Auth;
+using pote.Config.Admin.Api.Helpers;
+using pote.Config.Admin.Api.Model.RequestResponse;
+using pote.Config.DataProvider.Interfaces;
+
+namespace pote.Config.Admin.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    /// <summary>Failed logins take at least this long, uniformly, regardless of failure cause.</summary>
+    public static readonly TimeSpan MinimumFailureDuration = TimeSpan.FromMilliseconds(500);
+
+    private readonly ILogger<AuthController> _logger;
+    private readonly AuthService _authService;
+    private readonly IUserDataAccess _users;
+    private readonly IAuthProviderSetup _provider;
+    private readonly IAuditLogHandler _auditLogHandler;
+
+    public AuthController(ILogger<AuthController> logger, AuthService authService, IUserDataAccess users,
+        IAuthProviderSetup provider, IAuditLogHandler auditLogHandler)
+    {
+        _logger = logger;
+        _authService = authService;
+        _users = users;
+        _provider = provider;
+        _auditLogHandler = auditLogHandler;
+    }
+
+    [HttpGet("provider")]
+    [AllowAnonymous]
+    public ActionResult<object> GetProvider() => Ok(_provider.ProviderMetadata);
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    [EnableRateLimiting("auth")]
+    public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+    {
+        Response.Headers.CacheControl = "no-store";
+        var started = DateTime.UtcNow;
+        try
+        {
+            var result = await _authService.Login(request.Username, request.Password, cancellationToken);
+            if (result == null)
+            {
+                var attempted = (request.Username ?? string.Empty).Trim();
+                if (attempted.Length > 100) attempted = attempted[..100];
+                await this.AuditLog(Guid.Empty.ToString(), "LoginFailed", _auditLogHandler.AuditLogUser, attempted);
+                await DelayToUniformDuration(started, cancellationToken);
+                return Unauthorized();
+            }
+            await this.AuditLog(Guid.Empty.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
+            return Ok(ToResponse(result));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Login failed unexpectedly");
+            await DelayToUniformDuration(started, cancellationToken);
+            return Unauthorized();
+        }
+    }
+
+    [HttpPost("redeem")]
+    [AllowAnonymous]
+    [EnableRateLimiting("auth")]
+    public async Task<ActionResult<LoginResponse>> Redeem([FromBody] RedeemRequest request, CancellationToken cancellationToken)
+    {
+        Response.Headers.CacheControl = "no-store";
+        try
+        {
+            var result = await _authService.Redeem(request.Token, request.Password, cancellationToken);
+            if (result == null)
+                return BadRequest(new { errors = new[] { "The link is invalid or has expired." } });
+            await this.AuditLog(Guid.Empty.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
+            return Ok(ToResponse(result));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Redeem failed unexpectedly");
+            return BadRequest(new { errors = new[] { "The link is invalid or has expired." } });
+        }
+    }
+
+    [HttpPost("logout")]
+    [Authorize]
+    public async Task<ActionResult> Logout(CancellationToken cancellationToken)
+    {
+        var token = User.FindFirstValue("sessionToken");
+        if (!string.IsNullOrEmpty(token))
+            await _users.DeleteSession(token, cancellationToken);
+        return Ok();
+    }
+
+    [HttpPost("change-password")]
+    [Authorize(Policy = AuthPolicies.RealUser)]
+    public async Task<ActionResult> ChangePassword([FromBody] ChangePasswordRequest request, CancellationToken cancellationToken)
+    {
+        var userId = Guid.Parse(User.FindFirstValue(AuthPolicies.UserIdClaim)!);
+        var keepToken = User.FindFirstValue("sessionToken") ?? string.Empty;
+        var passwordError = PasswordPolicy.Validate(request.NewPassword);
+        if (passwordError != null)
+            return BadRequest(new { errors = new[] { passwordError } });
+
+        var ok = await _authService.ChangePassword(userId, request.CurrentPassword, request.NewPassword, keepToken, cancellationToken);
+        if (!ok)
+            return BadRequest(new { errors = new[] { "The current password is incorrect." } });
+
+        await this.AuditLog(userId.ToString(), "PasswordChanged", _auditLogHandler.AuditLogUser);
+        return Ok();
+    }
+
+    private static async Task DelayToUniformDuration(DateTime started, CancellationToken cancellationToken)
+    {
+        var elapsed = DateTime.UtcNow - started;
+        if (elapsed < MinimumFailureDuration)
+            await Task.Delay(MinimumFailureDuration - elapsed, cancellationToken);
+    }
+
+    private static LoginResponse ToResponse(LoginResult result) => new()
+    {
+        Token = result.Token,
+        ExpiresUtc = result.ExpiresUtc,
+        Username = result.Username,
+        Role = result.Role,
+        IsGuest = result.IsGuest
+    };
+}

--- a/src/Config.Admin.Api/Controllers/AuthController.cs
+++ b/src/Config.Admin.Api/Controllers/AuthController.cs
@@ -54,7 +54,7 @@ public class AuthController : ControllerBase
                 await DelayToUniformDuration(started, cancellationToken);
                 return Unauthorized();
             }
-            await this.AuditLog(result.UserId.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
+            await this.AuditLog(result.UserId.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username, actingUsername: result.Username);
             return Ok(ToResponse(result));
         }
         catch (Exception ex)
@@ -76,7 +76,11 @@ public class AuthController : ControllerBase
             var result = await _authService.Redeem(request.Token, request.Password, cancellationToken);
             if (result == null)
                 return BadRequest(new { errors = new[] { "The link is invalid or has expired." } });
-            await this.AuditLog(result.UserId.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
+            if (result.Redemption == "invite")
+                await this.AuditLog(result.UserId.ToString(), "UserCreated", _auditLogHandler.AuditLogUser, $"{result.Username} ({result.Role}, via invite)", actingUsername: result.Username);
+            else if (result.Redemption == "reset")
+                await this.AuditLog(result.UserId.ToString(), "PasswordChanged", _auditLogHandler.AuditLogUser, $"{result.Username} (via reset link)", actingUsername: result.Username);
+            await this.AuditLog(result.UserId.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username, actingUsername: result.Username);
             return Ok(ToResponse(result));
         }
         catch (Exception ex)

--- a/src/Config.Admin.Api/Controllers/AuthController.cs
+++ b/src/Config.Admin.Api/Controllers/AuthController.cs
@@ -54,7 +54,7 @@ public class AuthController : ControllerBase
                 await DelayToUniformDuration(started, cancellationToken);
                 return Unauthorized();
             }
-            await this.AuditLog(Guid.Empty.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
+            await this.AuditLog(result.UserId.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
             return Ok(ToResponse(result));
         }
         catch (Exception ex)
@@ -76,7 +76,7 @@ public class AuthController : ControllerBase
             var result = await _authService.Redeem(request.Token, request.Password, cancellationToken);
             if (result == null)
                 return BadRequest(new { errors = new[] { "The link is invalid or has expired." } });
-            await this.AuditLog(Guid.Empty.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
+            await this.AuditLog(result.UserId.ToString(), "Login", _auditLogHandler.AuditLogUser, result.Username);
             return Ok(ToResponse(result));
         }
         catch (Exception ex)

--- a/src/Config.Admin.Api/Controllers/ConfigParseController.cs
+++ b/src/Config.Admin.Api/Controllers/ConfigParseController.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.Shared;
 
 namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("Configuration")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class ConfigParseController : ControllerBase
 {
     private readonly ILogger<ConfigParseController> _logger;

--- a/src/Config.Admin.Api/Controllers/ConfigurationsController.cs
+++ b/src/Config.Admin.Api/Controllers/ConfigurationsController.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json.Linq;
 using pote.Config.Admin.Api.Helpers;
@@ -6,14 +6,15 @@ using pote.Config.Admin.Api.Mappers;
 using pote.Config.Admin.Api.Model;
 using pote.Config.Admin.Api.Model.RequestResponse;
 using pote.Config.Admin.Api.Services;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.DataProvider.Interfaces;
 
 namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class ConfigurationsController : ControllerBase
 {
     private readonly ILogger<ConfigurationsController> _logger;

--- a/src/Config.Admin.Api/Controllers/DependencyGraphController.cs
+++ b/src/Config.Admin.Api/Controllers/DependencyGraphController.cs
@@ -2,13 +2,14 @@
 using Microsoft.Extensions.Caching.Memory;
 using pote.Config.Admin.Api.Model.RequestResponse;
 using pote.Config.Admin.Api.Services;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 
 namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class DependencyGraphController : ControllerBase
 {
     private readonly ILogger<DependencyGraphController> _logger;

--- a/src/Config.Admin.Api/Controllers/EnvironmentsController.cs
+++ b/src/Config.Admin.Api/Controllers/EnvironmentsController.cs
@@ -1,10 +1,11 @@
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using pote.Config.Admin.Api.Helpers;
 using pote.Config.Admin.Api.Mappers;
 using pote.Config.Admin.Api.Model.RequestResponse;
 using pote.Config.Admin.Api.Services;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.DataProvider.Interfaces;
 using pote.Config.Shared;
 
@@ -12,7 +13,7 @@ namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class EnvironmentsController : ControllerBase
 {
     private readonly ILogger<EnvironmentsController> _logger;

--- a/src/Config.Admin.Api/Controllers/SecretsController.cs
+++ b/src/Config.Admin.Api/Controllers/SecretsController.cs
@@ -4,7 +4,8 @@ using pote.Config.Admin.Api.Helpers;
 using pote.Config.Admin.Api.Mappers;
 using pote.Config.Admin.Api.Model.RequestResponse;
 using pote.Config.Admin.Api.Services;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.DataProvider.Interfaces;
 using pote.Config.Shared;
 
@@ -12,7 +13,7 @@ namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class SecretsController : ControllerBase
 {
     private readonly ILogger<SecretsController> _logger;

--- a/src/Config.Admin.Api/Controllers/SettingsController.cs
+++ b/src/Config.Admin.Api/Controllers/SettingsController.cs
@@ -1,14 +1,15 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using pote.Config.Admin.Api.Helpers;
 using pote.Config.Admin.Api.Model.RequestResponse;
-using pote.Config.Auth;
+using Microsoft.AspNetCore.Authorization;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.DataProvider.Interfaces;
 
 namespace pote.Config.Admin.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-[ApiKey]
+[Authorize(Policy = AuthPolicies.RealUser)]
 public class SettingsController : ControllerBase
 {
     private readonly ILogger<SettingsController> _logger;

--- a/src/Config.Admin.Api/Controllers/UsersController.cs
+++ b/src/Config.Admin.Api/Controllers/UsersController.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using pote.Config.Admin.Api.Auth;
@@ -9,9 +9,11 @@ using pote.Config.DbModel;
 
 namespace pote.Config.Admin.Api.Controllers;
 
+// Note: no controller-level policy - [Authorize] attributes combine with AND,
+// which would lock the guest-only create endpoint out. Every action carries
+// its own policy instead (verified by unit test).
 [ApiController]
 [Route("api/users")]
-[Authorize(Policy = AuthPolicies.AdminOnly)]
 public class UsersController : ControllerBase
 {
     private readonly ILogger<UsersController> _logger;
@@ -31,6 +33,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult<UserListResponse>> GetAll(CancellationToken cancellationToken)
     {
         try
@@ -66,6 +69,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPost("invites")]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult<TokenResponse>> CreateInvite([FromBody] CreateInviteRequest request, CancellationToken cancellationToken)
     {
         Response.Headers.CacheControl = "no-store";
@@ -103,6 +107,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpDelete("invites/{username}")]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult> RevokeInvite(string username, CancellationToken cancellationToken)
     {
         try
@@ -119,6 +124,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPost("{username}/reset")]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult<TokenResponse>> CreateResetLink(string username, CancellationToken cancellationToken)
     {
         Response.Headers.CacheControl = "no-store";
@@ -146,6 +152,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPut("{username}/role")]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult> ChangeRole(string username, [FromBody] ChangeRoleRequest request, CancellationToken cancellationToken)
     {
         try
@@ -171,6 +178,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpDelete("{username}")]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult> Delete(string username, [FromQuery] bool permanent, CancellationToken cancellationToken)
     {
         try
@@ -207,6 +215,7 @@ public class UsersController : ControllerBase
     }
 
     [HttpPost("{username}/restore")]
+    [Authorize(Policy = AuthPolicies.AdminOnly)]
     public async Task<ActionResult> Restore(string username, CancellationToken cancellationToken)
     {
         try

--- a/src/Config.Admin.Api/Controllers/UsersController.cs
+++ b/src/Config.Admin.Api/Controllers/UsersController.cs
@@ -64,7 +64,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to get users");
-            return Problem(ex.Message);
+            return Problem("Failed to load users.");
         }
     }
 
@@ -102,7 +102,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to create invite");
-            return Problem(ex.Message);
+            return Problem("Failed to create the invite.");
         }
     }
 
@@ -112,14 +112,15 @@ public class UsersController : ControllerBase
     {
         try
         {
-            await _users.DeleteInvite(username, cancellationToken);
-            await this.AuditLog(Guid.Empty.ToString(), "InviteRevoked", _auditLogHandler.AuditLogUser, username);
+            var inviteId = await _users.DeleteInvite(username, cancellationToken);
+            if (inviteId != null)
+                await this.AuditLog(inviteId.Value.ToString(), "InviteRevoked", _auditLogHandler.AuditLogUser, username);
             return Ok();
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to revoke invite");
-            return Problem(ex.Message);
+            return Problem("Failed to revoke the invite.");
         }
     }
 
@@ -147,7 +148,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to create reset link");
-            return Problem(ex.Message);
+            return Problem("Failed to create the reset link.");
         }
     }
 
@@ -173,7 +174,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to change role");
-            return Problem(ex.Message);
+            return Problem("Failed to change the role.");
         }
     }
 
@@ -210,7 +211,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to delete user");
-            return Problem(ex.Message);
+            return Problem("Failed to delete the user.");
         }
     }
 
@@ -231,7 +232,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to restore user");
-            return Problem(ex.Message);
+            return Problem("Failed to restore the user.");
         }
     }
 
@@ -261,7 +262,7 @@ public class UsersController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to create user");
-            return Problem(ex.Message);
+            return Problem("Failed to create the user.");
         }
     }
 }

--- a/src/Config.Admin.Api/Controllers/UsersController.cs
+++ b/src/Config.Admin.Api/Controllers/UsersController.cs
@@ -244,7 +244,7 @@ public class UsersController : ControllerBase
         try
         {
             var result = await _authService.CreateFirstUser(request.Username, request.Password, cancellationToken);
-            await this.AuditLog(Guid.Empty.ToString(), "UserCreated", _auditLogHandler.AuditLogUser, $"{result.Username} (Admin, by guest)");
+            await this.AuditLog(result.UserId.ToString(), "UserCreated", _auditLogHandler.AuditLogUser, $"{result.Username} (Admin, by guest)");
             return Ok(new LoginResponse
             {
                 Token = result.Token,

--- a/src/Config.Admin.Api/Controllers/UsersController.cs
+++ b/src/Config.Admin.Api/Controllers/UsersController.cs
@@ -1,0 +1,258 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using pote.Config.Admin.Api.Auth;
+using pote.Config.Admin.Api.Helpers;
+using pote.Config.Admin.Api.Model.RequestResponse;
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.Admin.Api.Controllers;
+
+[ApiController]
+[Route("api/users")]
+[Authorize(Policy = AuthPolicies.AdminOnly)]
+public class UsersController : ControllerBase
+{
+    private readonly ILogger<UsersController> _logger;
+    private readonly IUserDataAccess _users;
+    private readonly AuthService _authService;
+    private readonly AuthSettings _settings;
+    private readonly IAuditLogHandler _auditLogHandler;
+
+    public UsersController(ILogger<UsersController> logger, IUserDataAccess users, AuthService authService,
+        AuthSettings settings, IAuditLogHandler auditLogHandler)
+    {
+        _logger = logger;
+        _users = users;
+        _authService = authService;
+        _settings = settings;
+        _auditLogHandler = auditLogHandler;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<UserListResponse>> GetAll(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var users = await _users.GetUsers(cancellationToken);
+            var invites = await _users.GetInvites(cancellationToken);
+            return Ok(new UserListResponse
+            {
+                Users = users.Select(u => new UserInfo
+                {
+                    Id = u.Id,
+                    Username = u.Username,
+                    Role = u.Role,
+                    Deleted = u.Deleted,
+                    IsGuest = u.IsGuest,
+                    CreatedUtc = u.CreatedUtc,
+                    LastLoginUtc = u.LastLoginUtc
+                }).ToList(),
+                Invites = invites.Select(i => new InviteInfo
+                {
+                    Username = i.Username,
+                    Role = i.Role,
+                    CreatedBy = i.CreatedBy,
+                    ExpiresUtc = i.ExpiresUtc
+                }).ToList()
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get users");
+            return Problem(ex.Message);
+        }
+    }
+
+    [HttpPost("invites")]
+    public async Task<ActionResult<TokenResponse>> CreateInvite([FromBody] CreateInviteRequest request, CancellationToken cancellationToken)
+    {
+        Response.Headers.CacheControl = "no-store";
+        try
+        {
+            var usernameError = UsernameRules.Validate(request.Username, out var username);
+            if (usernameError != null)
+                return BadRequest(new { errors = new[] { usernameError } });
+            if (!UserRoles.IsValid(request.Role))
+                return BadRequest(new { errors = new[] { "Role must be Admin or User." } });
+
+            var existing = await _users.GetUserByUsername(username, cancellationToken);
+            if (existing != null)
+                return BadRequest(new { errors = new[] { existing.Deleted
+                    ? "That username belongs to a deleted user. Restore it instead."
+                    : "That username is already taken." } });
+
+            var invite = new UserInvite
+            {
+                Token = TokenGenerator.NewToken(),
+                Username = username,
+                Role = request.Role,
+                CreatedBy = User.Identity!.Name!,
+                ExpiresUtc = DateTime.UtcNow.AddDays(_settings.InviteLifetimeDays)
+            };
+            await _users.UpsertInvite(invite, cancellationToken);
+            await this.AuditLog(invite.Id.ToString(), "InviteCreated", _auditLogHandler.AuditLogUser, $"{username} ({request.Role})");
+            return Ok(new TokenResponse { Token = invite.Token, ExpiresUtc = invite.ExpiresUtc });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create invite");
+            return Problem(ex.Message);
+        }
+    }
+
+    [HttpDelete("invites/{username}")]
+    public async Task<ActionResult> RevokeInvite(string username, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _users.DeleteInvite(username, cancellationToken);
+            await this.AuditLog(Guid.Empty.ToString(), "InviteRevoked", _auditLogHandler.AuditLogUser, username);
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to revoke invite");
+            return Problem(ex.Message);
+        }
+    }
+
+    [HttpPost("{username}/reset")]
+    public async Task<ActionResult<TokenResponse>> CreateResetLink(string username, CancellationToken cancellationToken)
+    {
+        Response.Headers.CacheControl = "no-store";
+        try
+        {
+            var user = await _users.GetUserByUsername(username, cancellationToken);
+            if (user == null || user.Deleted || user.IsGuest)
+                return BadRequest(new { errors = new[] { "No active user with that username." } });
+
+            var reset = new PasswordReset
+            {
+                Token = TokenGenerator.NewToken(),
+                UserId = user.Id,
+                ExpiresUtc = DateTime.UtcNow.AddDays(_settings.InviteLifetimeDays)
+            };
+            await _users.UpsertReset(reset, cancellationToken);
+            await this.AuditLog(user.Id.ToString(), "ResetLinkCreated", _auditLogHandler.AuditLogUser, user.Username);
+            return Ok(new TokenResponse { Token = reset.Token, ExpiresUtc = reset.ExpiresUtc });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create reset link");
+            return Problem(ex.Message);
+        }
+    }
+
+    [HttpPut("{username}/role")]
+    public async Task<ActionResult> ChangeRole(string username, [FromBody] ChangeRoleRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!UserRoles.IsValid(request.Role))
+                return BadRequest(new { errors = new[] { "Role must be Admin or User." } });
+
+            var user = await _users.GetUserByUsername(username, cancellationToken);
+            if (user == null || user.Deleted || user.IsGuest)
+                return BadRequest(new { errors = new[] { "No active user with that username." } });
+
+            if (!await _users.UpdateRole(user.Id, request.Role, cancellationToken))
+                return BadRequest(new { errors = new[] { "Cannot demote the last admin." } });
+
+            await this.AuditLog(user.Id.ToString(), "RoleChanged", _auditLogHandler.AuditLogUser, $"{user.Username} -> {request.Role}");
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to change role");
+            return Problem(ex.Message);
+        }
+    }
+
+    [HttpDelete("{username}")]
+    public async Task<ActionResult> Delete(string username, [FromQuery] bool permanent, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var user = await _users.GetUserByUsername(username, cancellationToken);
+            if (user == null || user.IsGuest)
+                return BadRequest(new { errors = new[] { "No user with that username." } });
+
+            if (permanent)
+            {
+                if (!user.Deleted)
+                    return BadRequest(new { errors = new[] { "Only an already deleted user can be permanently deleted." } });
+                await _users.PermanentlyDeleteUser(user.Id, cancellationToken);
+                await this.AuditLog(user.Id.ToString(), "UserPermanentlyDeleted", _auditLogHandler.AuditLogUser, user.Username);
+                return Ok();
+            }
+
+            if (string.Equals(user.Username, User.Identity?.Name, StringComparison.OrdinalIgnoreCase))
+                return BadRequest(new { errors = new[] { "You cannot delete yourself." } });
+            if (user.Deleted)
+                return BadRequest(new { errors = new[] { "The user is already deleted." } });
+
+            if (!await _users.SoftDeleteUser(user.Id, cancellationToken))
+                return BadRequest(new { errors = new[] { "Cannot delete the last admin." } });
+
+            await this.AuditLog(user.Id.ToString(), "UserDeleted", _auditLogHandler.AuditLogUser, user.Username);
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete user");
+            return Problem(ex.Message);
+        }
+    }
+
+    [HttpPost("{username}/restore")]
+    public async Task<ActionResult> Restore(string username, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var user = await _users.GetUserByUsername(username, cancellationToken);
+            if (user == null || !user.Deleted)
+                return BadRequest(new { errors = new[] { "No deleted user with that username." } });
+
+            await _users.RestoreUser(user.Id, cancellationToken);
+            await this.AuditLog(user.Id.ToString(), "UserRestored", _auditLogHandler.AuditLogUser, user.Username);
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to restore user");
+            return Problem(ex.Message);
+        }
+    }
+
+    /// <summary>Guest-only: create the first Admin directly (real users are invite-only).</summary>
+    [HttpPost]
+    [Authorize(Policy = AuthPolicies.GuestOnly)]
+    public async Task<ActionResult<LoginResponse>> CreateFirstUser([FromBody] CreateUserRequest request, CancellationToken cancellationToken)
+    {
+        Response.Headers.CacheControl = "no-store";
+        try
+        {
+            var result = await _authService.CreateFirstUser(request.Username, request.Password, cancellationToken);
+            await this.AuditLog(Guid.Empty.ToString(), "UserCreated", _auditLogHandler.AuditLogUser, $"{result.Username} (Admin, by guest)");
+            return Ok(new LoginResponse
+            {
+                Token = result.Token,
+                ExpiresUtc = result.ExpiresUtc,
+                Username = result.Username,
+                Role = result.Role,
+                IsGuest = result.IsGuest
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { errors = new[] { ex.Message } });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create user");
+            return Problem(ex.Message);
+        }
+    }
+}

--- a/src/Config.Admin.Api/Helpers/AuditLogger.cs
+++ b/src/Config.Admin.Api/Helpers/AuditLogger.cs
@@ -1,12 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace pote.Config.Admin.Api.Helpers;
 
 public static class AuditLogger
 {
-    public static async Task AuditLog(this ControllerBase c, string id, string action, Func<string, string, string, Task> func)
+    public static async Task AuditLog(this ControllerBase c, string id, string action, Func<string, string, string?, string, string, Task> func, string content = "")
     {
         var remoteIpAddress = c.Request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        await func(id, remoteIpAddress, action);
+        var username = c.User.Identity?.IsAuthenticated == true ? c.User.Identity.Name : null;
+        await func(id, remoteIpAddress, username, action, content);
     }
 }

--- a/src/Config.Admin.Api/Helpers/AuditLogger.cs
+++ b/src/Config.Admin.Api/Helpers/AuditLogger.cs
@@ -4,10 +4,24 @@ namespace pote.Config.Admin.Api.Helpers;
 
 public static class AuditLogger
 {
-    public static async Task AuditLog(this ControllerBase c, string id, string action, Func<string, string, string?, string, string, Task> func, string content = "")
+    /// <summary>
+    /// Writes an audit entry. The acting username is taken from the authenticated
+    /// principal; pass <paramref name="actingUsername"/> to override it on anonymous
+    /// endpoints that establish identity themselves (login, redeem).
+    /// An audit failure is logged but never turns a completed operation into an
+    /// API error (clients would retry work that already happened).
+    /// </summary>
+    public static async Task AuditLog(this ControllerBase c, string id, string action, Func<string, string, string?, string, string, Task> func, string content = "", string? actingUsername = null)
     {
-        var remoteIpAddress = c.Request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        var username = c.User.Identity?.IsAuthenticated == true ? c.User.Identity.Name : null;
-        await func(id, remoteIpAddress, username, action, content);
+        try
+        {
+            var remoteIpAddress = c.Request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var username = actingUsername ?? (c.User.Identity?.IsAuthenticated == true ? c.User.Identity.Name : null);
+            await func(id, remoteIpAddress, username, action, content);
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Audit write failed for action {Action} on {EntityId}", action, id);
+        }
     }
 }

--- a/src/Config.Admin.Api/Program.cs
+++ b/src/Config.Admin.Api/Program.cs
@@ -1,9 +1,11 @@
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 using Df.ServiceControllerExtensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.OpenApi.Models;
+using pote.Config.Admin.Api.Auth;
 using pote.Config.Admin.Api.Services;
-using pote.Config.Auth;
 using pote.Config.DataProvider.File;
 using pote.Config.DataProvider.Interfaces;
 using pote.Config.DataProvider.SqlServer;
@@ -27,13 +29,13 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
-    c.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
-        Description = "API Key needed to access the endpoints. X-API-Key: My_API_Key",
+        Description = "Session token from POST api/auth/login. Authorization: Bearer <token>",
         In = ParameterLocation.Header,
-        Name = "X-API-Key",
-        Type = SecuritySchemeType.ApiKey,
-        Scheme = "ApiKeyScheme"
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer"
     });
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
     {
@@ -43,11 +45,8 @@ builder.Services.AddSwaggerGen(c =>
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.SecurityScheme,
-                    Id = "ApiKey"
-                },
-                Scheme = "ApiKeyScheme",
-                Name = "X-API-Key",
-                In = ParameterLocation.Header
+                    Id = "Bearer"
+                }
             },
             new List<string>()
         }
@@ -95,8 +94,38 @@ else
 builder.Services.AddScoped<IDependencyGraphService, DependencyGraphService>();
 builder.Services.AddScoped<IParser, Parser>();
 
-builder.Services.AddScoped<IApiKeyValidation, ApiKeyValidation>();
-builder.Services.AddScoped<ApiKeyAuthenticationFilter>();
+// Auth provider selection (ADR-0002): the app consumes claims; the provider
+// decides how requests become claims. Only "Local" is implemented.
+var authSettings = builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();
+builder.Services.AddSingleton(authSettings);
+IAuthProviderSetup authProvider = authSettings.Provider.Equals("Local", StringComparison.OrdinalIgnoreCase)
+    ? new LocalAuthProviderSetup()
+    : throw new InvalidOperationException($"Unknown Auth:Provider '{authSettings.Provider}'. Only 'Local' is supported.");
+builder.Services.AddSingleton(authProvider);
+authProvider.ConfigureServices(builder.Services, builder.Configuration);
+authProvider.ConfigureAuthentication(builder.Services.AddAuthentication(AuthPolicies.SchemeName));
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy(AuthPolicies.RealUser, p => p.RequireAuthenticatedUser()
+        .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == AuthPolicies.GuestClaim)));
+    options.AddPolicy(AuthPolicies.AdminOnly, p => p.RequireAuthenticatedUser()
+        .RequireRole(pote.Config.DbModel.UserRoles.Admin)
+        .RequireAssertion(ctx => !ctx.User.HasClaim(c => c.Type == AuthPolicies.GuestClaim)));
+    options.AddPolicy(AuthPolicies.GuestOnly, p => p.RequireAuthenticatedUser()
+        .RequireClaim(AuthPolicies.GuestClaim));
+    // Endpoints without an explicit attribute require a real (non-guest) user.
+    options.FallbackPolicy = options.GetPolicy(AuthPolicies.RealUser);
+});
+
+// Brute-force and resource-exhaustion mitigation on the anonymous auth endpoints.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy("auth", httpContext => RateLimitPartition.GetFixedWindowLimiter(
+        httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+        _ => new FixedWindowRateLimiterOptions { PermitLimit = 10, Window = TimeSpan.FromMinutes(1) }));
+});
 
 builder.Services.Configure<JsonOptions>(options =>
 {
@@ -105,13 +134,30 @@ builder.Services.Configure<JsonOptions>(options =>
 
 var app = builder.Build();
 
+// Fail fast when the Local provider has no user storage (ADR-0005), then seed
+// the guest bootstrap user if the store is empty.
+using (var scope = app.Services.CreateScope())
+{
+    try
+    {
+        var authService = scope.ServiceProvider.GetRequiredService<pote.Config.Admin.Api.Auth.AuthService>();
+        await authService.EnsureGuestSeeded(CancellationToken.None);
+    }
+    catch (NotSupportedException ex)
+    {
+        Log.Fatal(ex, "Startup aborted: {Message}", ex.Message);
+        throw;
+    }
+}
+
 app.UseSwagger();
 app.UseSwaggerUI();
 
 app.UseCors("allowall");
 
-//app.UseHttpsRedirection();
-//app.UseAuthorization();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRateLimiter();
 
 app.MapControllers();
 

--- a/src/Config.Admin.Api/Program.cs
+++ b/src/Config.Admin.Api/Program.cs
@@ -67,7 +67,7 @@ builder.Services.AddCors(p => p.AddPolicy("allowall", policy =>
 
 builder.Services.AddConfiguration<EncryptionSettings>(builder.Configuration);
 
-var dataProviderType = builder.Configuration["DataProvider"] ?? "File";
+var dataProviderType = builder.Configuration["DataProvider"] ?? "SqlServer";
 if (dataProviderType.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
 {
     var connStr = builder.Configuration["SqlServer:ConnectionString"];
@@ -78,6 +78,7 @@ if (dataProviderType.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
     builder.Services.AddScoped<IAdminDataProvider, pote.Config.DataProvider.SqlServer.AdminDataProvider>();
     builder.Services.AddScoped<IAuditLogHandler, pote.Config.DataProvider.SqlServer.AuditLogHandler>();
     builder.Services.AddScoped<IDataProvider, SqlServerDataProvider>();
+    builder.Services.AddScoped<IUserDataAccess, pote.Config.DataProvider.SqlServer.UserDataAccess>();
 }
 else
 {
@@ -89,6 +90,7 @@ else
     builder.Services.AddScoped<IAdminDataProvider, pote.Config.DataProvider.File.AdminDataProvider>();
     builder.Services.AddScoped<IAuditLogHandler, pote.Config.DataProvider.File.AuditLogHandler>();
     builder.Services.AddScoped<IDataProvider, FileDataProvider>();
+    builder.Services.AddScoped<IUserDataAccess, pote.Config.DataProvider.File.UserDataAccess>();
 }
 builder.Services.AddScoped<IDependencyGraphService, DependencyGraphService>();
 builder.Services.AddScoped<IParser, Parser>();

--- a/src/Config.Admin.Api/appsettings.json
+++ b/src/Config.Admin.Api/appsettings.json
@@ -17,6 +17,11 @@
     ]
   },
   "AllowedHosts": "*",
+  "Auth": {
+    "Provider": "Local",
+    "SessionLifetimeHours": 8,
+    "InviteLifetimeDays": 7
+  },
   "DataProvider": "SqlServer",
   "FileDatabase": {
     "Directory": "D:\\ConfigurationDatabase"

--- a/src/Config.Admin.WebClient/e2e/auth.spec.ts
+++ b/src/Config.Admin.WebClient/e2e/auth.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+import { makeFixtures, mockAdminApi, seedSession, type Fixtures } from './mocks';
+
+let fixtures: Fixtures;
+
+test.beforeEach(async ({ page }) => {
+	fixtures = makeFixtures();
+	await mockAdminApi(page, fixtures);
+});
+
+test('unauthenticated visit redirects to login; logging in lands on configurations', async ({
+	page
+}) => {
+	await page.goto('/');
+	await expect(page).toHaveURL(/\/login/);
+
+	await page.getByLabel('Username').fill('anna');
+	await page.getByLabel('Password').fill('CorrectHorse1!Battery');
+	await page.getByRole('button', { name: 'Log in' }).click();
+
+	await expect(page).toHaveURL(/\/$/);
+	await expect(page.getByRole('cell', { name: 'Database' })).toBeVisible();
+});
+
+test('failed login shows an error and stays on the login page', async ({ page }) => {
+	await page.goto('/login');
+	await page.getByLabel('Username').fill('anna');
+	await page.getByLabel('Password').fill('wrong');
+	await page.getByRole('button', { name: 'Log in' }).click();
+
+	await expect(page.getByText('Wrong username or password.')).toBeVisible();
+	await expect(page).toHaveURL(/\/login/);
+});
+
+test('guest login is locked to the first-user screen and can create the first admin', async ({
+	page
+}) => {
+	await page.goto('/login');
+	await page.getByLabel('Username').fill('guest');
+	await page.getByLabel('Password').fill('guest');
+	await page.getByRole('button', { name: 'Log in' }).click();
+
+	await expect(page).toHaveURL(/\/first-user/);
+
+	// Trying to escape the first-user screen bounces back.
+	await page.goto('/secrets');
+	await expect(page).toHaveURL(/\/first-user/);
+
+	await page.getByLabel('Username').fill('anna');
+	await page.getByLabel('Password', { exact: true }).fill('CorrectHorse1!Battery');
+	await page.getByLabel('Repeat password').fill('CorrectHorse1!Battery');
+	await page.getByRole('button', { name: 'Create user and log in' }).click();
+
+	await expect(page).toHaveURL(/\/$/);
+	expect(fixtures.createdUsers).toHaveLength(1);
+});
+
+test('invite redemption via fragment token sets password and logs in', async ({ page }) => {
+	await page.goto('/redeem#token=valid-invite');
+
+	await page.getByLabel('New password').fill('CorrectHorse1!Battery');
+	await page.getByLabel('Repeat password').fill('CorrectHorse1!Battery');
+	await page.getByRole('button', { name: 'Set password and log in' }).click();
+
+	await expect(page).toHaveURL(/\/$/);
+});
+
+test('redeem without a token shows the invalid-link message', async ({ page }) => {
+	await page.goto('/redeem');
+	await expect(page.getByText('Invalid link')).toBeVisible();
+});
+
+test('guest sees no admin navigation', async ({ page }) => {
+	await seedSession(page, { username: 'guest', isGuest: true });
+	await page.goto('/');
+	await expect(page).toHaveURL(/\/first-user/);
+	await expect(page.getByRole('link', { name: 'Secrets' })).toHaveCount(0);
+});

--- a/src/Config.Admin.WebClient/e2e/mocks.ts
+++ b/src/Config.Admin.WebClient/e2e/mocks.ts
@@ -80,11 +80,32 @@ export function makeFixtures() {
 		savedConfigurations: [] as unknown[],
 		savedSecrets: [] as unknown[],
 		/** When set, POST Configurations fails with these error messages. */
-		saveErrors: null as string[] | null
+		saveErrors: null as string[] | null,
+		/** Users created via guest first-user or invite redemption. */
+		createdUsers: [] as unknown[]
 	};
 }
 
 export type Fixtures = ReturnType<typeof makeFixtures>;
+
+const sessionResponse = (username: string, role: string, isGuest: boolean) => ({
+	token: 'e2e-token',
+	expiresUtc: new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString(),
+	username,
+	role,
+	isGuest
+});
+
+/** Puts a valid session in localStorage before the app boots. */
+export async function seedSession(
+	page: Page,
+	{ username = 'anna', role = 'Admin', isGuest = false } = {}
+) {
+	await page.addInitScript(
+		(session) => localStorage.setItem('configservice.session', JSON.stringify(session)),
+		sessionResponse(username, role, isGuest)
+	);
+}
 
 /** Intercepts every Admin API call the client makes. */
 export async function mockAdminApi(page: Page, fixtures: Fixtures) {
@@ -110,6 +131,29 @@ export async function mockAdminApi(page: Page, fixtures: Fixtures) {
 				}
 			});
 		}
+
+		// Auth endpoints
+		if (path === '/api/auth/provider') return json({ type: 'local' });
+		if (path === '/api/auth/login' && method === 'POST') {
+			const body = route.request().postDataJSON() as { username: string; password: string };
+			if (body.username === 'guest' && body.password === 'guest')
+				return json(sessionResponse('guest', 'Admin', true));
+			if (body.password === 'wrong') return json(null, 401);
+			return json(sessionResponse(body.username, 'Admin', false));
+		}
+		if (path === '/api/auth/redeem' && method === 'POST') {
+			const body = route.request().postDataJSON() as { token: string };
+			if (body.token !== 'valid-invite')
+				return json({ errors: ['The link is invalid or has expired.'] }, 400);
+			return json(sessionResponse('invitee', 'User', false));
+		}
+		if (path === '/api/auth/logout' && method === 'POST') return json({});
+		if (path === '/api/users' && method === 'POST') {
+			const body = route.request().postDataJSON() as { username: string };
+			fixtures.createdUsers.push(body);
+			return json(sessionResponse(body.username, 'Admin', false));
+		}
+		if (path === '/api/users' && method === 'GET') return json({ users: [], invites: [] });
 
 		if (path === '/Configurations' && method === 'GET')
 			return json({ configurations: fixtures.configurations });

--- a/src/Config.Admin.WebClient/e2e/smoke.spec.ts
+++ b/src/Config.Admin.WebClient/e2e/smoke.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@playwright/test';
-import { makeFixtures, mockAdminApi, type Fixtures } from './mocks';
+import { makeFixtures, mockAdminApi, seedSession, type Fixtures } from './mocks';
 
 let fixtures: Fixtures;
 
 test.beforeEach(async ({ page }) => {
 	fixtures = makeFixtures();
 	await mockAdminApi(page, fixtures);
+	await seedSession(page);
 });
 
 test('configurations list → open → edit → save round-trip', async ({ page }) => {

--- a/src/Config.Admin.WebClient/src/lib/api/authApi.ts
+++ b/src/Config.Admin.WebClient/src/lib/api/authApi.ts
@@ -1,0 +1,82 @@
+import { apiFetch, getJson, postJson, seg, type ApiResult } from './client';
+
+export type LoginResponse = {
+	token: string;
+	expiresUtc: string;
+	username: string;
+	role: string;
+	isGuest: boolean;
+};
+
+export type ProviderResponse = { type: string };
+
+export type UserInfo = {
+	id: string;
+	username: string;
+	role: string;
+	deleted: boolean;
+	isGuest: boolean;
+	createdUtc: string;
+	lastLoginUtc: string | null;
+};
+
+export type InviteInfo = {
+	username: string;
+	role: string;
+	createdBy: string;
+	expiresUtc: string;
+};
+
+export type UserListResponse = { users: UserInfo[]; invites: InviteInfo[] };
+export type TokenResponse = { token: string; expiresUtc: string };
+
+export const getProvider = (): Promise<ApiResult<ProviderResponse>> => getJson('api/auth/provider');
+
+export const login = (username: string, password: string): Promise<ApiResult<LoginResponse>> =>
+	postJson('api/auth/login', { username, password });
+
+export const redeem = (token: string, password: string): Promise<ApiResult<LoginResponse>> =>
+	postJson('api/auth/redeem', { token, password });
+
+export const logout = (): Promise<ApiResult<void>> => postJson('api/auth/logout');
+
+export const changePassword = (
+	currentPassword: string,
+	newPassword: string
+): Promise<ApiResult<void>> =>
+	postJson('api/auth/change-password', { currentPassword, newPassword });
+
+// User management (admin-only, except createFirstUser which is guest-only)
+export const getUsers = (): Promise<ApiResult<UserListResponse>> => getJson('api/users');
+
+export const createInvite = (username: string, role: string): Promise<ApiResult<TokenResponse>> =>
+	postJson('api/users/invites', { username, role });
+
+export const revokeInvite = (username: string): Promise<ApiResult<void>> =>
+	deleteJsonPath(`api/users/invites/${seg(username)}`);
+
+export const createResetLink = (username: string): Promise<ApiResult<TokenResponse>> =>
+	postJson(`api/users/${seg(username)}/reset`);
+
+export const changeRole = (username: string, role: string): Promise<ApiResult<void>> =>
+	putJson(`api/users/${seg(username)}/role`, { role });
+
+export const deleteUser = (username: string, permanent = false): Promise<ApiResult<void>> =>
+	deleteJsonPath(`api/users/${seg(username)}?permanent=${permanent}`);
+
+export const restoreUser = (username: string): Promise<ApiResult<void>> =>
+	postJson(`api/users/${seg(username)}/restore`);
+
+export const createFirstUser = (
+	username: string,
+	password: string
+): Promise<ApiResult<LoginResponse>> => postJson('api/users', { username, password });
+
+// Small local helpers for verbs client.ts does not export yet.
+function putJson<T>(path: string, body?: unknown): Promise<ApiResult<T>> {
+	return apiFetch<T>(path, { method: 'PUT', body: body === undefined ? null : JSON.stringify(body) });
+}
+
+function deleteJsonPath<T>(path: string): Promise<ApiResult<T>> {
+	return apiFetch<T>(path, { method: 'DELETE' });
+}

--- a/src/Config.Admin.WebClient/src/lib/api/client.test.ts
+++ b/src/Config.Admin.WebClient/src/lib/api/client.test.ts
@@ -1,15 +1,31 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setRuntimeConfigForTests } from '$lib/runtime-config';
+import { clearSession, resetSessionForTests, setSession } from '$lib/auth/session.svelte';
 import { apiFetch } from './client';
 
+const { gotoMock } = vi.hoisted(() => ({ gotoMock: vi.fn() }));
+vi.mock('$app/navigation', () => ({ goto: gotoMock }));
+
+const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
 beforeEach(() => {
-	setRuntimeConfigForTests({ adminApiUrl: 'http://api.test', apiKey: 'test-key' });
+	localStorage.clear();
+	resetSessionForTests();
+	gotoMock.mockReset();
+	setRuntimeConfigForTests({ adminApiUrl: 'http://api.test' });
 });
-afterEach(() => setRuntimeConfigForTests(null));
+afterEach(() => {
+	localStorage.clear();
+	resetSessionForTests();
+	setRuntimeConfigForTests(null);
+});
 
 const respond =
 	(body: BodyInit | null, init?: ResponseInit) =>
 	async (): Promise<Response> => new Response(body, init);
+
+const loggedIn = () =>
+	setSession({ token: 'tok123', expiresUtc: future, username: 'anna', role: 'Admin', isGuest: false });
 
 describe('apiFetch', () => {
 	it('returns ok with parsed JSON for 2xx responses', async () => {
@@ -17,20 +33,41 @@ describe('apiFetch', () => {
 		expect(result).toEqual({ ok: true, value: { a: 1 } });
 	});
 
-	it('sends the API key header and joins the URL against the base', async () => {
+	it('sends the bearer token and joins the URL against the base', async () => {
+		loggedIn();
 		let seenUrl = '';
-		let seenKey: string | null = null;
-		await apiFetch(
-			'Configurations/abc',
-			{},
-			async (input, init) => {
-				seenUrl = String(input);
-				seenKey = new Headers(init?.headers).get('X-API-Key');
-				return new Response('{}');
-			}
-		);
+		let seenAuth: string | null = null;
+		await apiFetch('Configurations/abc', {}, async (input, init) => {
+			seenUrl = String(input);
+			seenAuth = new Headers(init?.headers).get('Authorization');
+			return new Response('{}');
+		});
 		expect(seenUrl).toBe('http://api.test/Configurations/abc');
-		expect(seenKey).toBe('test-key');
+		expect(seenAuth).toBe('Bearer tok123');
+	});
+
+	it('sends no Authorization header without a session', async () => {
+		let seenAuth: string | null = 'unset';
+		await apiFetch('api/auth/login', {}, async (_input, init) => {
+			seenAuth = new Headers(init?.headers).get('Authorization');
+			return new Response('{}');
+		});
+		expect(seenAuth).toBeNull();
+	});
+
+	it('clears the session and redirects to /login on 401 with a session', async () => {
+		loggedIn();
+		const result = await apiFetch('x', {}, respond('', { status: 401 }));
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.status).toBe(401);
+		expect(localStorage.getItem('configservice.session')).toBeNull();
+		expect(gotoMock).toHaveBeenCalledWith('/login');
+	});
+
+	it('does not redirect on 401 without a session (failed login)', async () => {
+		const result = await apiFetch('api/auth/login', {}, respond('', { status: 401 }));
+		expect(result.ok).toBe(false);
+		expect(gotoMock).not.toHaveBeenCalled();
 	});
 
 	it('returns ok undefined for 204 and empty bodies', async () => {

--- a/src/Config.Admin.WebClient/src/lib/api/client.ts
+++ b/src/Config.Admin.WebClient/src/lib/api/client.ts
@@ -1,4 +1,6 @@
+import { goto } from '$app/navigation';
 import { getRuntimeConfig } from '$lib/runtime-config';
+import { clearSession, getSession } from '$lib/auth/session.svelte';
 
 export type ApiError = {
 	kind: 'network' | 'abort' | 'http' | 'invalid-json';
@@ -26,8 +28,8 @@ export function seg(value: string | number | boolean): string {
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
 /**
- * The one place requests are built and credentials attached (login-readiness
- * seam: swap the X-API-Key header for a bearer token here and nowhere else).
+ * The one place requests are built and the session token attached. On 401 with
+ * an active session, the session is cleared and the user sent to /login.
  * Never throws — every failure class maps to an ApiResult error.
  */
 export async function apiFetch<T>(
@@ -35,7 +37,8 @@ export async function apiFetch<T>(
 	init: RequestInit = {},
 	fetchFn: FetchLike = fetch
 ): Promise<ApiResult<T>> {
-	const { adminApiUrl, apiKey } = getRuntimeConfig();
+	const { adminApiUrl } = getRuntimeConfig();
+	const session = getSession();
 	const base = adminApiUrl.endsWith('/') ? adminApiUrl : adminApiUrl + '/';
 	let url: URL;
 	try {
@@ -49,7 +52,7 @@ export async function apiFetch<T>(
 		response = await fetchFn(url, {
 			...init,
 			headers: {
-				'X-API-Key': apiKey,
+				...(session ? { Authorization: `Bearer ${session.token}` } : {}),
 				...(init.body ? { 'Content-Type': 'application/json' } : {}),
 				...(init.headers ?? {})
 			}
@@ -69,6 +72,13 @@ export async function apiFetch<T>(
 	}
 
 	if (!response.ok) {
+		if (response.status === 401 && session) {
+			// The session was revoked or expired server-side; a 401 without a
+			// session (e.g. a failed login attempt) is the caller's to handle.
+			clearSession();
+			void goto('/login');
+			return fail({ kind: 'http', status: 401, message: 'Your session has expired. Please log in again.' });
+		}
 		let errors: string[] | undefined;
 		let message = `The Admin API returned HTTP ${response.status}`;
 		try {

--- a/src/Config.Admin.WebClient/src/lib/api/generated.d.ts
+++ b/src/Config.Admin.WebClient/src/lib/api/generated.d.ts
@@ -143,6 +143,197 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/provider": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["LoginRequest"];
+                    "text/json": components["schemas"]["LoginRequest"];
+                    "application/*+json": components["schemas"]["LoginRequest"];
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["LoginResponse"];
+                        "application/json": components["schemas"]["LoginResponse"];
+                        "text/json": components["schemas"]["LoginResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/redeem": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RedeemRequest"];
+                    "text/json": components["schemas"]["RedeemRequest"];
+                    "application/*+json": components["schemas"]["RedeemRequest"];
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["LoginResponse"];
+                        "application/json": components["schemas"]["LoginResponse"];
+                        "text/json": components["schemas"]["LoginResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ChangePasswordRequest"];
+                    "text/json": components["schemas"]["ChangePasswordRequest"];
+                    "application/*+json": components["schemas"]["ChangePasswordRequest"];
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/Configuration": {
         parameters: {
             query?: never;
@@ -697,6 +888,300 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["UserListResponse"];
+                        "application/json": components["schemas"]["UserListResponse"];
+                        "text/json": components["schemas"]["UserListResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CreateUserRequest"];
+                    "text/json": components["schemas"]["CreateUserRequest"];
+                    "application/*+json": components["schemas"]["CreateUserRequest"];
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["LoginResponse"];
+                        "application/json": components["schemas"]["LoginResponse"];
+                        "text/json": components["schemas"]["LoginResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/invites": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CreateInviteRequest"];
+                    "text/json": components["schemas"]["CreateInviteRequest"];
+                    "application/*+json": components["schemas"]["CreateInviteRequest"];
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["TokenResponse"];
+                        "application/json": components["schemas"]["TokenResponse"];
+                        "text/json": components["schemas"]["TokenResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/invites/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    username: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    username: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["TokenResponse"];
+                        "application/json": components["schemas"]["TokenResponse"];
+                        "text/json": components["schemas"]["TokenResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}/role": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    username: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ChangeRoleRequest"];
+                    "text/json": components["schemas"]["ChangeRoleRequest"];
+                    "application/*+json": components["schemas"]["ChangeRoleRequest"];
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: {
+                    permanent?: boolean;
+                };
+                header?: never;
+                path: {
+                    username: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    username: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -717,6 +1202,13 @@ export interface components {
         };
         ApplicationsResponse: {
             applications?: components["schemas"]["Application"][] | null;
+        };
+        ChangePasswordRequest: {
+            currentPassword?: string | null;
+            newPassword?: string | null;
+        };
+        ChangeRoleRequest: {
+            role?: string | null;
         };
         Configuration: {
             headerId?: string | null;
@@ -765,6 +1257,14 @@ export interface components {
         ConfigurationsResponse: {
             configurations?: components["schemas"]["ConfigurationHeader"][] | null;
         };
+        CreateInviteRequest: {
+            username?: string | null;
+            role?: string | null;
+        };
+        CreateUserRequest: {
+            username?: string | null;
+            password?: string | null;
+        };
         DependencyGraphResponse: {
             vertices?: components["schemas"]["Vertex"][] | null;
             edges?: components["schemas"]["Edge"][] | null;
@@ -797,11 +1297,34 @@ export interface components {
             /** Format: int32 */
             pageSize?: number;
         };
+        InviteInfo: {
+            username?: string | null;
+            role?: string | null;
+            createdBy?: string | null;
+            /** Format: date-time */
+            expiresUtc?: string;
+        };
+        LoginRequest: {
+            username?: string | null;
+            password?: string | null;
+        };
+        LoginResponse: {
+            token?: string | null;
+            /** Format: date-time */
+            expiresUtc?: string;
+            username?: string | null;
+            role?: string | null;
+            isGuest?: boolean;
+        };
         ParseRequest: {
             /** Format: byte */
             inputJson?: string | null;
             application?: string | null;
             environment?: string | null;
+        };
+        RedeemRequest: {
+            token?: string | null;
+            password?: string | null;
         };
         Secret: {
             headerId?: string | null;
@@ -840,6 +1363,27 @@ export interface components {
         };
         SettingsResponse: {
             settings?: components["schemas"]["Settings"];
+        };
+        TokenResponse: {
+            token?: string | null;
+            /** Format: date-time */
+            expiresUtc?: string;
+        };
+        UserInfo: {
+            /** Format: uuid */
+            id?: string;
+            username?: string | null;
+            role?: string | null;
+            deleted?: boolean;
+            isGuest?: boolean;
+            /** Format: date-time */
+            createdUtc?: string;
+            /** Format: date-time */
+            lastLoginUtc?: string | null;
+        };
+        UserListResponse: {
+            users?: components["schemas"]["UserInfo"][] | null;
+            invites?: components["schemas"]["InviteInfo"][] | null;
         };
         Vertex: {
             id?: string | null;

--- a/src/Config.Admin.WebClient/src/lib/auth/passwordPolicy.ts
+++ b/src/Config.Admin.WebClient/src/lib/auth/passwordPolicy.ts
@@ -1,0 +1,10 @@
+/** Client-side mirror of the server's PasswordPolicy (the server is authoritative). */
+export function validatePassword(password: string): string | null {
+	if (password.length < 16) return 'Password must be at least 16 characters.';
+	if (password.length > 128) return 'Password must be at most 128 characters.';
+	if (!/[a-z]/.test(password)) return 'Password must contain a lowercase letter.';
+	if (!/[A-Z]/.test(password)) return 'Password must contain an uppercase letter.';
+	if (!/[0-9]/.test(password)) return 'Password must contain a digit.';
+	if (!/[^a-zA-Z0-9]/.test(password)) return 'Password must contain a special character.';
+	return null;
+}

--- a/src/Config.Admin.WebClient/src/lib/auth/session.svelte.ts
+++ b/src/Config.Admin.WebClient/src/lib/auth/session.svelte.ts
@@ -1,0 +1,76 @@
+/**
+ * The client-side session: an opaque token plus display metadata, persisted in
+ * localStorage. The token is opaque bytes to the SPA regardless of which auth
+ * provider issued it (see GET api/auth/provider).
+ */
+export type SessionInfo = {
+	token: string;
+	/** ISO timestamp. Client-side convenience only — the server is authoritative. */
+	expiresUtc: string;
+	username: string;
+	role: string;
+	isGuest: boolean;
+};
+
+const STORAGE_KEY = 'configservice.session';
+
+let current = $state<SessionInfo | null>(null);
+let loaded = false;
+
+function isExpired(session: SessionInfo): boolean {
+	const expires = Date.parse(session.expiresUtc);
+	return Number.isNaN(expires) || expires <= Date.now();
+}
+
+/** Loads the persisted session (once); drops it when expired or malformed. */
+export function loadSession(): SessionInfo | null {
+	if (loaded) return current;
+	loaded = true;
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as SessionInfo;
+		if (
+			typeof parsed.token !== 'string' ||
+			parsed.token.length === 0 ||
+			typeof parsed.username !== 'string' ||
+			isExpired(parsed)
+		) {
+			localStorage.removeItem(STORAGE_KEY);
+			return null;
+		}
+		current = parsed;
+	} catch {
+		localStorage.removeItem(STORAGE_KEY);
+	}
+	return current;
+}
+
+export function getSession(): SessionInfo | null {
+	if (!loaded) loadSession();
+	if (current && isExpired(current)) clearSession();
+	return current;
+}
+
+export function setSession(session: SessionInfo): void {
+	loaded = true;
+	current = session;
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+}
+
+export function clearSession(): void {
+	loaded = true;
+	current = null;
+	localStorage.removeItem(STORAGE_KEY);
+}
+
+export function isAdmin(): boolean {
+	const session = getSession();
+	return session !== null && !session.isGuest && session.role === 'Admin';
+}
+
+/** Test hook: resets the module-level cache. */
+export function resetSessionForTests(): void {
+	loaded = false;
+	current = null;
+}

--- a/src/Config.Admin.WebClient/src/lib/auth/session.test.ts
+++ b/src/Config.Admin.WebClient/src/lib/auth/session.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	clearSession,
+	getSession,
+	isAdmin,
+	loadSession,
+	resetSessionForTests,
+	setSession,
+	type SessionInfo
+} from './session.svelte';
+
+const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const past = new Date(Date.now() - 60 * 1000).toISOString();
+
+const makeSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
+	token: 'tok123',
+	expiresUtc: future,
+	username: 'anna',
+	role: 'Admin',
+	isGuest: false,
+	...overrides
+});
+
+beforeEach(() => {
+	localStorage.clear();
+	resetSessionForTests();
+});
+afterEach(() => {
+	localStorage.clear();
+	resetSessionForTests();
+});
+
+describe('session store', () => {
+	it('persists and reloads a session', () => {
+		setSession(makeSession());
+		resetSessionForTests();
+		const loaded = loadSession();
+		expect(loaded?.username).toBe('anna');
+		expect(loaded?.token).toBe('tok123');
+	});
+
+	it('drops an expired session on load', () => {
+		setSession(makeSession({ expiresUtc: past }));
+		resetSessionForTests();
+		expect(loadSession()).toBeNull();
+		expect(localStorage.getItem('configservice.session')).toBeNull();
+	});
+
+	it('drops a session that expires while active', () => {
+		setSession(makeSession({ expiresUtc: past }));
+		expect(getSession()).toBeNull();
+	});
+
+	it('drops malformed storage content', () => {
+		localStorage.setItem('configservice.session', 'not json');
+		expect(loadSession()).toBeNull();
+	});
+
+	it('clearSession removes persisted state', () => {
+		setSession(makeSession());
+		clearSession();
+		expect(getSession()).toBeNull();
+		expect(localStorage.getItem('configservice.session')).toBeNull();
+	});
+
+	it('isAdmin is true only for non-guest admins', () => {
+		setSession(makeSession());
+		expect(isAdmin()).toBe(true);
+		setSession(makeSession({ role: 'User' }));
+		expect(isAdmin()).toBe(false);
+		setSession(makeSession({ isGuest: true }));
+		expect(isAdmin()).toBe(false);
+		clearSession();
+		expect(isAdmin()).toBe(false);
+	});
+});

--- a/src/Config.Admin.WebClient/src/lib/components/AppShell.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/AppShell.svelte
@@ -8,6 +8,7 @@
 	import MenuIcon from '@lucide/svelte/icons/menu';
 	import NavMenu from './NavMenu.svelte';
 	import ThemeMenu from './ThemeMenu.svelte';
+	import UserMenu from './UserMenu.svelte';
 	import ErrorBanner from './ErrorBanner.svelte';
 	import { clearPageError } from '$lib/stores/pageError.svelte';
 	import { initTheme } from '$lib/theme';
@@ -28,7 +29,7 @@
 			<div class="p-4 text-lg font-semibold">Configuration Admin</div>
 			<div class="flex-1"><NavMenu /></div>
 			<div class="border-t p-2">
-				<!-- Login-readiness seam: a user menu slots in here later. -->
+				<UserMenu />
 				<ThemeMenu />
 			</div>
 		</aside>
@@ -47,7 +48,7 @@
 					<Sheet.Content side="left" class="w-64 p-0">
 						<div class="p-4 text-lg font-semibold">Configuration Admin</div>
 						<NavMenu onNavigate={() => (mobileNavOpen = false)} />
-						<div class="border-t p-2"><ThemeMenu /></div>
+						<div class="border-t p-2"><UserMenu /><ThemeMenu /></div>
 					</Sheet.Content>
 				</Sheet.Root>
 				<span class="font-semibold">Configuration Admin</span>

--- a/src/Config.Admin.WebClient/src/lib/components/NavMenu.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/NavMenu.svelte
@@ -7,6 +7,8 @@
 	import AppWindowIcon from '@lucide/svelte/icons/app-window';
 	import GlobeIcon from '@lucide/svelte/icons/globe';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
+	import UsersIcon from '@lucide/svelte/icons/users';
+	import { isAdmin } from '$lib/auth/session.svelte';
 
 	let { onNavigate }: { onNavigate?: () => void } = $props();
 
@@ -16,7 +18,8 @@
 		{ href: '/applications', label: 'Applications', icon: AppWindowIcon },
 		{ href: '/environments', label: 'Environments', icon: GlobeIcon },
 		{ href: '/ApiKeys', label: 'Api keys', icon: KeyRoundIcon },
-		{ href: '/Settings', label: 'Settings', icon: SettingsIcon }
+		{ href: '/Settings', label: 'Settings', icon: SettingsIcon },
+		...(isAdmin() ? [{ href: '/users', label: 'Users', icon: UsersIcon }] : [])
 	];
 
 	const isActive = (href: string) =>

--- a/src/Config.Admin.WebClient/src/lib/components/UserMenu.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/UserMenu.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import UserIcon from '@lucide/svelte/icons/user';
+	import KeyIcon from '@lucide/svelte/icons/key';
+	import LogOutIcon from '@lucide/svelte/icons/log-out';
+	import { changePassword, logout } from '$lib/api/authApi';
+	import { clearSession, getSession } from '$lib/auth/session.svelte';
+	import { validatePassword } from '$lib/auth/passwordPolicy';
+
+	const session = getSession();
+
+	let changeOpen = $state(false);
+	let currentPassword = $state('');
+	let newPassword = $state('');
+	let confirm = $state('');
+	let error = $state('');
+	let busy = $state(false);
+
+	async function onLogout() {
+		await logout();
+		clearSession();
+		await goto('/login');
+	}
+
+	async function submitChange(event: SubmitEvent) {
+		event.preventDefault();
+		error = '';
+		const policyError = validatePassword(newPassword);
+		if (policyError) {
+			error = policyError;
+			return;
+		}
+		if (newPassword !== confirm) {
+			error = 'The passwords do not match.';
+			return;
+		}
+		busy = true;
+		const result = await changePassword(currentPassword, newPassword);
+		busy = false;
+		if (!result.ok) {
+			error = result.error.message;
+			return;
+		}
+		changeOpen = false;
+		currentPassword = newPassword = confirm = '';
+		toast.success('Password changed');
+	}
+</script>
+
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger>
+		{#snippet child({ props })}
+			<Button {...props} variant="ghost" size="sm" class="w-full justify-start gap-2">
+				<UserIcon class="size-4" />
+				{session?.username ?? ''}
+			</Button>
+		{/snippet}
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Content>
+		{#if !session?.isGuest}
+			<DropdownMenu.Item onclick={() => (changeOpen = true)}>
+				<KeyIcon class="size-4" /> Change password
+			</DropdownMenu.Item>
+		{/if}
+		<DropdownMenu.Item onclick={onLogout}>
+			<LogOutIcon class="size-4" /> Log out
+		</DropdownMenu.Item>
+	</DropdownMenu.Content>
+</DropdownMenu.Root>
+
+<Dialog.Root bind:open={changeOpen}>
+	<Dialog.Content>
+		<Dialog.Header><Dialog.Title>Change password</Dialog.Title></Dialog.Header>
+		<form class="space-y-4" onsubmit={submitChange}>
+			<div class="space-y-2">
+				<Label for="current-password">Current password</Label>
+				<Input
+					id="current-password"
+					type="password"
+					bind:value={currentPassword}
+					autocomplete="current-password"
+					required
+				/>
+			</div>
+			<div class="space-y-2">
+				<Label for="new-password">New password</Label>
+				<Input
+					id="new-password"
+					type="password"
+					bind:value={newPassword}
+					autocomplete="new-password"
+					required
+				/>
+			</div>
+			<div class="space-y-2">
+				<Label for="confirm-password">Repeat new password</Label>
+				<Input
+					id="confirm-password"
+					type="password"
+					bind:value={confirm}
+					autocomplete="new-password"
+					required
+				/>
+			</div>
+			{#if error}
+				<p class="text-sm text-destructive" role="alert">{error}</p>
+			{/if}
+			<Dialog.Footer>
+				<Button type="submit" disabled={busy}>{busy ? 'Saving…' : 'Change password'}</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/Config.Admin.WebClient/src/lib/runtime-config.test.ts
+++ b/src/Config.Admin.WebClient/src/lib/runtime-config.test.ts
@@ -8,20 +8,18 @@ function fetchReturning(body: unknown, ok = true, status = 200): typeof fetch {
 
 describe('loadRuntimeConfig', () => {
 	it('parses a valid config', async () => {
-		const cfg = await loadRuntimeConfig(
-			fetchReturning({ adminApiUrl: 'http://localhost:34246', apiKey: 'k' })
-		);
+		const cfg = await loadRuntimeConfig(fetchReturning({ adminApiUrl: 'http://localhost:34246' }));
 		expect(cfg.adminApiUrl).toBe('http://localhost:34246');
-		expect(cfg.apiKey).toBe('k');
 		setRuntimeConfigForTests(null);
 	});
 
-	it('rejects a config with a missing field', async () => {
+	it('rejects a config with a missing adminApiUrl', async () => {
+		await expect(loadRuntimeConfig(fetchReturning({}))).rejects.toThrow('missing "adminApiUrl"');
+	});
+
+	it('rejects a non-URL adminApiUrl', async () => {
 		await expect(loadRuntimeConfig(fetchReturning({ adminApiUrl: 'x' }))).rejects.toThrow(
 			RuntimeConfigError
-		);
-		await expect(loadRuntimeConfig(fetchReturning({ apiKey: 'k' }))).rejects.toThrow(
-			'missing "adminApiUrl"'
 		);
 	});
 

--- a/src/Config.Admin.WebClient/src/lib/runtime-config.ts
+++ b/src/Config.Admin.WebClient/src/lib/runtime-config.ts
@@ -1,6 +1,5 @@
 export type RuntimeConfig = {
 	adminApiUrl: string;
-	apiKey: string;
 };
 
 export class RuntimeConfigError extends Error {}
@@ -40,12 +39,7 @@ export async function loadRuntimeConfig(
 	} catch {
 		throw new RuntimeConfigError('config.json "adminApiUrl" is not a valid http(s) URL');
 	}
-	if (typeof cfg.apiKey !== 'string' || cfg.apiKey.length === 0) {
-		throw new RuntimeConfigError('config.json is missing "apiKey"');
-	}
-	config = { adminApiUrl: cfg.adminApiUrl, apiKey: cfg.apiKey };
-	// Login-readiness seam: a future auth gate slots in here, after config
-	// load and before the app renders.
+	config = { adminApiUrl: cfg.adminApiUrl };
 	return config;
 }
 

--- a/src/Config.Admin.WebClient/src/routes/+layout.svelte
+++ b/src/Config.Admin.WebClient/src/routes/+layout.svelte
@@ -3,36 +3,69 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import AppShell from '$lib/components/AppShell.svelte';
 	import { loadRuntimeConfig } from '$lib/runtime-config';
+	import { getSession, loadSession } from '$lib/auth/session.svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 
 	let { children } = $props();
 
-	// Boot sequence: load config.json → (future auth gate) → render app.
+	// Boot sequence: load config.json → auth gate → render app.
 	let bootState = $state<'loading' | 'ready' | 'error'>('loading');
 	let bootError = $state('');
 	loadRuntimeConfig().then(
-		() => (bootState = 'ready'),
+		() => {
+			loadSession();
+			bootState = 'ready';
+		},
 		(error: Error) => {
 			bootError = error.message;
 			bootState = 'error';
 		}
 	);
+
+	// Routes rendered without a session (login form, invite/reset redemption).
+	const anonymousRoutes = ['/login', '/redeem'];
+	const isAnonymousRoute = $derived(anonymousRoutes.some((r) => page.url.pathname.startsWith(r)));
+
+	// Auth gate: no session → /login; guest session → locked to /first-user.
+	const session = $derived(bootState === 'ready' ? getSession() : null);
+	$effect(() => {
+		if (bootState !== 'ready') return;
+		if (!session && !isAnonymousRoute) {
+			void goto('/login');
+		} else if (session?.isGuest && page.url.pathname !== '/first-user') {
+			void goto('/first-user');
+		}
+	});
+
+	// Bare pages render without the app shell (nav would only offer dead ends).
+	const isBarePage = $derived(isAnonymousRoute || page.url.pathname.startsWith('/first-user'));
 </script>
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<meta name="referrer" content="same-origin" />
 </svelte:head>
 
 {#if bootState === 'loading'}
 	<div class="flex h-screen items-center justify-center text-muted-foreground">Loading…</div>
 {:else if bootState === 'ready'}
-	<AppShell>{@render children()}</AppShell>
+	{#if isBarePage}
+		{@render children()}
+	{:else if session}
+		<AppShell>{@render children()}</AppShell>
+	{:else}
+		<div class="flex h-screen items-center justify-center text-muted-foreground">
+			Redirecting to login…
+		</div>
+	{/if}
 {:else}
 	<div class="flex h-screen flex-col items-center justify-center gap-2 p-8 text-center">
 		<h1 class="text-2xl font-semibold text-destructive">Configuration Admin failed to start</h1>
 		<p class="text-lg">{bootError}</p>
 		<p class="text-muted-foreground">
 			The application requires a valid <code>config.json</code> next to <code>index.html</code>,
-			containing <code>adminApiUrl</code> and <code>apiKey</code>.
+			containing <code>adminApiUrl</code>.
 		</p>
 	</div>
 {/if}

--- a/src/Config.Admin.WebClient/src/routes/first-user/+page.svelte
+++ b/src/Config.Admin.WebClient/src/routes/first-user/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { createFirstUser } from '$lib/api/authApi';
+	import { getSession, setSession } from '$lib/auth/session.svelte';
+	import { validatePassword } from '$lib/auth/passwordPolicy';
+
+	let username = $state('');
+	let password = $state('');
+	let confirm = $state('');
+	let error = $state('');
+	let busy = $state(false);
+
+	const policyError = $derived(password.length > 0 ? validatePassword(password) : null);
+
+	async function submit(event: SubmitEvent) {
+		event.preventDefault();
+		error = '';
+		if (policyError) {
+			error = policyError;
+			return;
+		}
+		if (password !== confirm) {
+			error = 'The passwords do not match.';
+			return;
+		}
+		busy = true;
+		const result = await createFirstUser(username.trim(), password);
+		busy = false;
+		if (!result.ok) {
+			error = result.error.message;
+			return;
+		}
+		// The new admin is logged in and the guest user is gone.
+		setSession(result.value);
+		await goto('/');
+	}
+</script>
+
+<svelte:head><title>Create your user — Configuration Admin</title></svelte:head>
+
+<div class="flex min-h-screen items-center justify-center p-4">
+	<form class="w-full max-w-sm space-y-4 rounded-lg border bg-card p-6 shadow-sm" onsubmit={submit}>
+		<h1 class="text-xl font-semibold">Welcome</h1>
+		<p class="text-sm text-muted-foreground">
+			You are logged in as <strong>{getSession()?.username ?? 'guest'}</strong>. Create your own
+			administrator account — the guest user disappears as soon as you log in with it.
+		</p>
+		<div class="space-y-2">
+			<Label for="username">Username</Label>
+			<Input id="username" bind:value={username} autocomplete="username" required autofocus />
+		</div>
+		<div class="space-y-2">
+			<Label for="password">Password</Label>
+			<Input id="password" type="password" bind:value={password} autocomplete="new-password" required />
+			{#if policyError}
+				<p class="text-sm text-muted-foreground">{policyError}</p>
+			{/if}
+		</div>
+		<div class="space-y-2">
+			<Label for="confirm">Repeat password</Label>
+			<Input id="confirm" type="password" bind:value={confirm} autocomplete="new-password" required />
+		</div>
+		{#if error}
+			<p class="text-sm text-destructive" role="alert">{error}</p>
+		{/if}
+		<Button type="submit" class="w-full" disabled={busy}>
+			{busy ? 'Creating…' : 'Create user and log in'}
+		</Button>
+	</form>
+</div>

--- a/src/Config.Admin.WebClient/src/routes/login/+page.svelte
+++ b/src/Config.Admin.WebClient/src/routes/login/+page.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { login } from '$lib/api/authApi';
+	import { setSession } from '$lib/auth/session.svelte';
+
+	let username = $state('');
+	let password = $state('');
+	let error = $state('');
+	let busy = $state(false);
+
+	async function submit(event: SubmitEvent) {
+		event.preventDefault();
+		error = '';
+		busy = true;
+		const result = await login(username, password);
+		busy = false;
+		if (!result.ok) {
+			error =
+				result.error.status === 401
+					? 'Wrong username or password.'
+					: result.error.status === 429
+						? 'Too many attempts. Wait a minute and try again.'
+						: result.error.message;
+			return;
+		}
+		setSession(result.value);
+		await goto(result.value.isGuest ? '/first-user' : '/');
+	}
+</script>
+
+<svelte:head><title>Log in — Configuration Admin</title></svelte:head>
+
+<div class="flex min-h-screen items-center justify-center p-4">
+	<form class="w-full max-w-sm space-y-4 rounded-lg border bg-card p-6 shadow-sm" onsubmit={submit}>
+		<h1 class="text-xl font-semibold">Configuration Admin</h1>
+		<div class="space-y-2">
+			<Label for="username">Username</Label>
+			<Input id="username" bind:value={username} autocomplete="username" required autofocus />
+		</div>
+		<div class="space-y-2">
+			<Label for="password">Password</Label>
+			<Input
+				id="password"
+				type="password"
+				bind:value={password}
+				autocomplete="current-password"
+				required
+			/>
+		</div>
+		{#if error}
+			<p class="text-sm text-destructive" role="alert">{error}</p>
+		{/if}
+		<Button type="submit" class="w-full" disabled={busy}>
+			{busy ? 'Logging in…' : 'Log in'}
+		</Button>
+	</form>
+</div>

--- a/src/Config.Admin.WebClient/src/routes/redeem/+page.svelte
+++ b/src/Config.Admin.WebClient/src/routes/redeem/+page.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { redeem } from '$lib/api/authApi';
+	import { setSession } from '$lib/auth/session.svelte';
+	import { validatePassword } from '$lib/auth/passwordPolicy';
+
+	// The token travels in the URL fragment (never the query string) so it stays
+	// out of server logs and Referer headers; strip it from the URL immediately.
+	let token = $state('');
+	$effect(() => {
+		const match = /(?:^|[#&])token=([^&]+)/.exec(location.hash);
+		if (match) {
+			token = decodeURIComponent(match[1]);
+			history.replaceState(null, '', location.pathname);
+		}
+	});
+
+	let password = $state('');
+	let confirm = $state('');
+	let error = $state('');
+	let busy = $state(false);
+
+	const policyError = $derived(password.length > 0 ? validatePassword(password) : null);
+
+	async function submit(event: SubmitEvent) {
+		event.preventDefault();
+		error = '';
+		if (policyError) {
+			error = policyError;
+			return;
+		}
+		if (password !== confirm) {
+			error = 'The passwords do not match.';
+			return;
+		}
+		busy = true;
+		const result = await redeem(token, password);
+		busy = false;
+		if (!result.ok) {
+			error = result.error.message;
+			return;
+		}
+		setSession(result.value);
+		await goto('/');
+	}
+</script>
+
+<svelte:head><title>Set password — Configuration Admin</title></svelte:head>
+
+<div class="flex min-h-screen items-center justify-center p-4">
+	{#if !token}
+		<div class="w-full max-w-sm space-y-2 rounded-lg border bg-card p-6 text-center shadow-sm">
+			<h1 class="text-xl font-semibold">Invalid link</h1>
+			<p class="text-muted-foreground">
+				This page needs an invite or reset link. Ask an administrator for a new one.
+			</p>
+		</div>
+	{:else}
+		<form
+			class="w-full max-w-sm space-y-4 rounded-lg border bg-card p-6 shadow-sm"
+			onsubmit={submit}
+		>
+			<h1 class="text-xl font-semibold">Choose your password</h1>
+			<p class="text-sm text-muted-foreground">
+				At least 16 characters with an uppercase letter, a lowercase letter, a digit, and a special
+				character.
+			</p>
+			<div class="space-y-2">
+				<Label for="password">New password</Label>
+				<Input
+					id="password"
+					type="password"
+					bind:value={password}
+					autocomplete="new-password"
+					required
+					autofocus
+				/>
+				{#if policyError}
+					<p class="text-sm text-muted-foreground">{policyError}</p>
+				{/if}
+			</div>
+			<div class="space-y-2">
+				<Label for="confirm">Repeat password</Label>
+				<Input id="confirm" type="password" bind:value={confirm} autocomplete="new-password" required />
+			</div>
+			{#if error}
+				<p class="text-sm text-destructive" role="alert">{error}</p>
+			{/if}
+			<Button type="submit" class="w-full" disabled={busy}>
+				{busy ? 'Saving…' : 'Set password and log in'}
+			</Button>
+		</form>
+	{/if}
+</div>

--- a/src/Config.Admin.WebClient/src/routes/users/+page.svelte
+++ b/src/Config.Admin.WebClient/src/routes/users/+page.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+	import { toast } from 'svelte-sonner';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Checkbox } from '$lib/components/ui/checkbox';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Table from '$lib/components/ui/table';
+	import {
+		changeRole,
+		createInvite,
+		createResetLink,
+		deleteUser,
+		getUsers,
+		restoreUser,
+		revokeInvite,
+		type InviteInfo,
+		type UserInfo
+	} from '$lib/api/authApi';
+	import { getSession } from '$lib/auth/session.svelte';
+	import { setPageError } from '$lib/stores/pageError.svelte';
+
+	let users = $state<UserInfo[]>([]);
+	let invites = $state<InviteInfo[]>([]);
+	let showDeleted = $state(false);
+	let loading = $state(true);
+
+	// Invite dialog
+	let inviteOpen = $state(false);
+	let inviteUsername = $state('');
+	let inviteRole = $state('User');
+	let inviteError = $state('');
+
+	// Link dialog (shows a copyable invite/reset link)
+	let linkOpen = $state(false);
+	let linkTitle = $state('');
+	let linkUrl = $state('');
+
+	const visibleUsers = $derived(showDeleted ? users : users.filter((u) => !u.deleted));
+	const me = $derived(getSession()?.username?.toLowerCase());
+
+	async function reload() {
+		loading = true;
+		const result = await getUsers();
+		loading = false;
+		if (!result.ok) {
+			setPageError(result.error.message);
+			return;
+		}
+		users = result.value.users ?? [];
+		invites = result.value.invites ?? [];
+	}
+	reload();
+
+	function redeemUrl(token: string): string {
+		return `${location.origin}/redeem#token=${encodeURIComponent(token)}`;
+	}
+
+	async function copyLink() {
+		try {
+			await navigator.clipboard.writeText(linkUrl);
+			toast.success('Link copied to clipboard');
+		} catch {
+			toast.error('Could not copy to clipboard');
+		}
+	}
+
+	async function submitInvite(event: SubmitEvent) {
+		event.preventDefault();
+		inviteError = '';
+		const result = await createInvite(inviteUsername.trim(), inviteRole);
+		if (!result.ok) {
+			inviteError = result.error.message;
+			return;
+		}
+		inviteOpen = false;
+		inviteUsername = '';
+		linkTitle = 'Invite link';
+		linkUrl = redeemUrl(result.value.token);
+		linkOpen = true;
+		await reload();
+	}
+
+	async function onResetLink(user: UserInfo) {
+		const result = await createResetLink(user.username);
+		if (!result.ok) {
+			toast.error(result.error.message);
+			return;
+		}
+		linkTitle = `Reset link for ${user.username}`;
+		linkUrl = redeemUrl(result.value.token);
+		linkOpen = true;
+	}
+
+	async function onChangeRole(user: UserInfo, role: string) {
+		if (role === user.role) return;
+		const result = await changeRole(user.username, role);
+		if (!result.ok) {
+			toast.error(result.error.message);
+		} else {
+			toast.success(`${user.username} is now ${role}`);
+		}
+		await reload();
+	}
+
+	async function onDelete(user: UserInfo, permanent: boolean) {
+		const question = permanent
+			? `Permanently delete ${user.username}? This frees the username and cannot be undone.`
+			: `Delete ${user.username}? The user can be restored later.`;
+		if (!confirm(question)) return;
+		const result = await deleteUser(user.username, permanent);
+		if (!result.ok) toast.error(result.error.message);
+		await reload();
+	}
+
+	async function onRestore(user: UserInfo) {
+		const result = await restoreUser(user.username);
+		if (!result.ok) toast.error(result.error.message);
+		else toast.success(`${user.username} restored`);
+		await reload();
+	}
+
+	async function onRevokeInvite(invite: InviteInfo) {
+		const result = await revokeInvite(invite.username);
+		if (!result.ok) toast.error(result.error.message);
+		await reload();
+	}
+
+	const formatDate = (iso: string | null) => (iso ? new Date(iso).toLocaleString() : '—');
+</script>
+
+<svelte:head><title>Users</title></svelte:head>
+
+<div class="space-y-6">
+	<div class="flex flex-wrap items-center justify-between gap-2">
+		<h1 class="text-2xl font-semibold">Users</h1>
+		<div class="flex items-center gap-4">
+			<label class="flex items-center gap-2 text-sm">
+				<Checkbox bind:checked={showDeleted} /> Show deleted
+			</label>
+			<Button onclick={() => (inviteOpen = true)}>Invite user</Button>
+		</div>
+	</div>
+
+	{#if loading}
+		<p class="text-muted-foreground">Loading…</p>
+	{:else}
+		<Table.Root>
+			<Table.Header>
+				<Table.Row>
+					<Table.Head>Username</Table.Head>
+					<Table.Head>Role</Table.Head>
+					<Table.Head>Last login</Table.Head>
+					<Table.Head>Created</Table.Head>
+					<Table.Head class="text-right">Actions</Table.Head>
+				</Table.Row>
+			</Table.Header>
+			<Table.Body>
+				{#each visibleUsers as user (user.id)}
+					<Table.Row class={user.deleted ? 'opacity-60' : ''}>
+						<Table.Cell class="font-medium">
+							{user.username}
+							{#if user.isGuest}<Badge variant="secondary" class="ml-2">guest</Badge>{/if}
+							{#if user.deleted}<Badge variant="destructive" class="ml-2">deleted</Badge>{/if}
+						</Table.Cell>
+						<Table.Cell>
+							{#if user.deleted || user.isGuest}
+								{user.role}
+							{:else}
+								<select
+									class="rounded-md border bg-background px-2 py-1 text-sm"
+									value={user.role}
+									onchange={(e) => onChangeRole(user, e.currentTarget.value)}
+								>
+									<option value="Admin">Admin</option>
+									<option value="User">User</option>
+								</select>
+							{/if}
+						</Table.Cell>
+						<Table.Cell>{formatDate(user.lastLoginUtc)}</Table.Cell>
+						<Table.Cell>{formatDate(user.createdUtc)}</Table.Cell>
+						<Table.Cell class="space-x-1 text-right">
+							{#if user.deleted}
+								<Button variant="outline" size="sm" onclick={() => onRestore(user)}>Restore</Button>
+								<Button variant="destructive" size="sm" onclick={() => onDelete(user, true)}>
+									Delete permanently
+								</Button>
+							{:else if !user.isGuest}
+								<Button variant="outline" size="sm" onclick={() => onResetLink(user)}>
+									Reset link
+								</Button>
+								{#if user.username.toLowerCase() !== me}
+									<Button variant="destructive" size="sm" onclick={() => onDelete(user, false)}>
+										Delete
+									</Button>
+								{/if}
+							{/if}
+						</Table.Cell>
+					</Table.Row>
+				{/each}
+			</Table.Body>
+		</Table.Root>
+
+		{#if invites.length > 0}
+			<div class="space-y-2">
+				<h2 class="text-lg font-semibold">Pending invites</h2>
+				<Table.Root>
+					<Table.Header>
+						<Table.Row>
+							<Table.Head>Username</Table.Head>
+							<Table.Head>Role</Table.Head>
+							<Table.Head>Invited by</Table.Head>
+							<Table.Head>Expires</Table.Head>
+							<Table.Head class="text-right">Actions</Table.Head>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{#each invites as invite (invite.username)}
+							<Table.Row>
+								<Table.Cell class="font-medium">{invite.username}</Table.Cell>
+								<Table.Cell>{invite.role}</Table.Cell>
+								<Table.Cell>{invite.createdBy}</Table.Cell>
+								<Table.Cell>{formatDate(invite.expiresUtc)}</Table.Cell>
+								<Table.Cell class="text-right">
+									<Button variant="outline" size="sm" onclick={() => onRevokeInvite(invite)}>
+										Revoke
+									</Button>
+								</Table.Cell>
+							</Table.Row>
+						{/each}
+					</Table.Body>
+				</Table.Root>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<Dialog.Root bind:open={inviteOpen}>
+	<Dialog.Content>
+		<Dialog.Header><Dialog.Title>Invite user</Dialog.Title></Dialog.Header>
+		<form class="space-y-4" onsubmit={submitInvite}>
+			<div class="space-y-2">
+				<Label for="invite-username">Username</Label>
+				<Input id="invite-username" bind:value={inviteUsername} required autofocus />
+			</div>
+			<div class="space-y-2">
+				<Label for="invite-role">Role</Label>
+				<select
+					id="invite-role"
+					class="w-full rounded-md border bg-background px-2 py-2 text-sm"
+					bind:value={inviteRole}
+				>
+					<option value="User">User</option>
+					<option value="Admin">Admin</option>
+				</select>
+			</div>
+			{#if inviteError}
+				<p class="text-sm text-destructive" role="alert">{inviteError}</p>
+			{/if}
+			<Dialog.Footer>
+				<Button type="submit">Create invite link</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root bind:open={linkOpen}>
+	<Dialog.Content>
+		<Dialog.Header><Dialog.Title>{linkTitle}</Dialog.Title></Dialog.Header>
+		<p class="text-sm text-muted-foreground">
+			Share this single-use link with the person yourself — nothing is emailed. It expires
+			automatically.
+		</p>
+		<Input readonly value={linkUrl} onclick={(e) => e.currentTarget.select()} />
+		<Dialog.Footer>
+			<Button onclick={copyLink}>Copy link</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/Config.Api/Program.cs
+++ b/src/Config.Api/Program.cs
@@ -38,7 +38,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddScoped<IParser, Parser>();
 
-var dataProviderType = builder.Configuration["DataProvider"] ?? "File";
+var dataProviderType = builder.Configuration["DataProvider"] ?? "SqlServer";
 if (dataProviderType.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
 {
     var connStr = builder.Configuration["SqlServer:ConnectionString"];

--- a/src/Config.DataProvider.File/AuditLogHandler.cs
+++ b/src/Config.DataProvider.File/AuditLogHandler.cs
@@ -1,4 +1,4 @@
-﻿using pote.Config.DataProvider.Interfaces;
+using pote.Config.DataProvider.Interfaces;
 
 namespace pote.Config.DataProvider.File;
 
@@ -11,33 +11,45 @@ public class AuditLogHandler : IAuditLogHandler
         _fileHandler = fileHandler;
     }
 
-    public async Task AuditLogConfiguration(string id, string callerIp, string content)
+    public async Task AuditLogConfiguration(string id, string callerIp, string? username, string action, string content)
     {
-        await _fileHandler.AuditLogConfiguration(id, $"{callerIp}{Environment.NewLine}{content}");
+        await _fileHandler.AuditLogConfiguration(id, Format(callerIp, username, action, content));
     }
 
-    public async Task AuditLogEnvironment(string id, string callerIp, string content)
+    public async Task AuditLogEnvironment(string id, string callerIp, string? username, string action, string content)
     {
-        await _fileHandler.AuditLogEnvironment(id, $"{callerIp}{Environment.NewLine}{content}");
+        await _fileHandler.AuditLogEnvironment(id, Format(callerIp, username, action, content));
     }
 
-    public async Task AuditLogApplication(string id, string callerIp, string content)
+    public async Task AuditLogApplication(string id, string callerIp, string? username, string action, string content)
     {
-        await _fileHandler.AuditLogApplication(id, $"{callerIp}{Environment.NewLine}{content}");
-    }
-    
-    public async Task AuditLogSettings(string id, string callerIp, string content)
-    {
-        await _fileHandler.AuditLogSettings($"{callerIp}{Environment.NewLine}{content}");
+        await _fileHandler.AuditLogApplication(id, Format(callerIp, username, action, content));
     }
 
-    public async Task AuditLogApiKeys(string id, string callerIp, string content)
+    public async Task AuditLogSettings(string id, string callerIp, string? username, string action, string content)
     {
-        await _fileHandler.AuditLogApiKeys($"{callerIp}{Environment.NewLine}{content}");
+        await _fileHandler.AuditLogSettings(Format(callerIp, username, action, content));
     }
 
-    public Task AuditLogSecrets(string id, string callerIp, string content)
+    public async Task AuditLogApiKeys(string id, string callerIp, string? username, string action, string content)
     {
-        return _fileHandler.AuditLogSecrets(id, $"{callerIp}{Environment.NewLine}{content}");
+        await _fileHandler.AuditLogApiKeys(Format(callerIp, username, action, content));
+    }
+
+    public Task AuditLogSecrets(string id, string callerIp, string? username, string action, string content)
+    {
+        return _fileHandler.AuditLogSecrets(id, Format(callerIp, username, action, content));
+    }
+
+    public Task AuditLogUser(string entityId, string callerIp, string? username, string action, string content)
+    {
+        // The file provider has no user store (see UserDataAccess), but user audit events
+        // are harmless to record; reuse the settings audit directory.
+        return _fileHandler.AuditLogSettings($"User {entityId}{Environment.NewLine}{Format(callerIp, username, action, content)}");
+    }
+
+    private static string Format(string callerIp, string? username, string action, string content)
+    {
+        return $"{callerIp} {username ?? "-"} {action}{Environment.NewLine}{content}";
     }
 }

--- a/src/Config.DataProvider.File/UserDataAccess.cs
+++ b/src/Config.DataProvider.File/UserDataAccess.cs
@@ -24,10 +24,10 @@ public class UserDataAccess : IUserDataAccess
     public Task HardDeleteGuest(CancellationToken cancellationToken) => throw NotSupported();
     public Task<bool> UpdateRole(Guid id, string role, CancellationToken cancellationToken) => throw NotSupported();
     public Task UpdateLastLogin(Guid id, DateTime utc, CancellationToken cancellationToken) => throw NotSupported();
-    public Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<bool> UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken) => throw NotSupported();
     public Task<List<UserInvite>> GetInvites(CancellationToken cancellationToken) => throw NotSupported();
     public Task UpsertInvite(UserInvite invite, CancellationToken cancellationToken) => throw NotSupported();
-    public Task DeleteInvite(string username, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<Guid?> DeleteInvite(string username, CancellationToken cancellationToken) => throw NotSupported();
     public Task<UserInvite?> ConsumeInvite(string token, CancellationToken cancellationToken) => throw NotSupported();
     public Task UpsertReset(PasswordReset reset, CancellationToken cancellationToken) => throw NotSupported();
     public Task<PasswordReset?> ConsumeReset(string token, CancellationToken cancellationToken) => throw NotSupported();

--- a/src/Config.DataProvider.File/UserDataAccess.cs
+++ b/src/Config.DataProvider.File/UserDataAccess.cs
@@ -1,0 +1,41 @@
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.DataProvider.File;
+
+/// <summary>
+/// The file provider has no user storage (ADR-0005: SQL Server is the primary provider).
+/// Every member throws so a misconfigured instance fails fast at startup.
+/// </summary>
+public class UserDataAccess : IUserDataAccess
+{
+    public const string NotSupportedMessage = "User login requires the SqlServer data provider. Set DataProvider=SqlServer and configure SqlServer:ConnectionString.";
+
+    private static NotSupportedException NotSupported() => new(NotSupportedMessage);
+
+    public Task<int> CountUsers(CancellationToken cancellationToken) => throw NotSupported();
+    public Task<List<User>> GetUsers(CancellationToken cancellationToken) => throw NotSupported();
+    public Task<User?> GetUserByUsername(string username, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<User?> GetUserById(Guid id, CancellationToken cancellationToken) => throw NotSupported();
+    public Task InsertUser(User user, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<bool> SoftDeleteUser(Guid id, CancellationToken cancellationToken) => throw NotSupported();
+    public Task RestoreUser(Guid id, CancellationToken cancellationToken) => throw NotSupported();
+    public Task PermanentlyDeleteUser(Guid id, CancellationToken cancellationToken) => throw NotSupported();
+    public Task HardDeleteGuest(CancellationToken cancellationToken) => throw NotSupported();
+    public Task<bool> UpdateRole(Guid id, string role, CancellationToken cancellationToken) => throw NotSupported();
+    public Task UpdateLastLogin(Guid id, DateTime utc, CancellationToken cancellationToken) => throw NotSupported();
+    public Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<List<UserInvite>> GetInvites(CancellationToken cancellationToken) => throw NotSupported();
+    public Task UpsertInvite(UserInvite invite, CancellationToken cancellationToken) => throw NotSupported();
+    public Task DeleteInvite(string username, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<UserInvite?> ConsumeInvite(string token, CancellationToken cancellationToken) => throw NotSupported();
+    public Task UpsertReset(PasswordReset reset, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<PasswordReset?> ConsumeReset(string token, CancellationToken cancellationToken) => throw NotSupported();
+    public Task DeleteResetsForUser(Guid userId, CancellationToken cancellationToken) => throw NotSupported();
+    public Task InsertSession(Session session, CancellationToken cancellationToken) => throw NotSupported();
+    public Task<SessionUser?> GetSessionUser(string token, CancellationToken cancellationToken) => throw NotSupported();
+    public Task DeleteSession(string token, CancellationToken cancellationToken) => throw NotSupported();
+    public Task DeleteSessionsForUser(Guid userId, CancellationToken cancellationToken) => throw NotSupported();
+    public Task DeleteOtherSessionsForUser(Guid userId, string keepToken, CancellationToken cancellationToken) => throw NotSupported();
+    public Task CleanupExpired(CancellationToken cancellationToken) => throw NotSupported();
+}

--- a/src/Config.DataProvider.Interfaces/IAuditLogHandler.cs
+++ b/src/Config.DataProvider.Interfaces/IAuditLogHandler.cs
@@ -2,10 +2,11 @@ namespace pote.Config.DataProvider.Interfaces;
 
 public interface IAuditLogHandler
 {
-    Task AuditLogConfiguration(string id, string callerIp, string content);
-    Task AuditLogEnvironment(string id, string callerIp, string content);
-    Task AuditLogApplication(string id, string callerIp, string content);
-    Task AuditLogSettings(string id, string callerIp, string content);
-    Task AuditLogApiKeys(string id, string callerIp, string content);
-    Task AuditLogSecrets(string id, string callerIp, string content);
+    Task AuditLogConfiguration(string id, string callerIp, string? username, string action, string content);
+    Task AuditLogEnvironment(string id, string callerIp, string? username, string action, string content);
+    Task AuditLogApplication(string id, string callerIp, string? username, string action, string content);
+    Task AuditLogSettings(string id, string callerIp, string? username, string action, string content);
+    Task AuditLogApiKeys(string id, string callerIp, string? username, string action, string content);
+    Task AuditLogSecrets(string id, string callerIp, string? username, string action, string content);
+    Task AuditLogUser(string entityId, string callerIp, string? username, string action, string content);
 }

--- a/src/Config.DataProvider.Interfaces/IUserDataAccess.cs
+++ b/src/Config.DataProvider.Interfaces/IUserDataAccess.cs
@@ -34,14 +34,15 @@ public interface IUserDataAccess
     /// <summary>Returns false when blocked (demoting the last active admin).</summary>
     Task<bool> UpdateRole(Guid id, string role, CancellationToken cancellationToken);
     Task UpdateLastLogin(Guid id, DateTime utc, CancellationToken cancellationToken);
-    /// <summary>When expectedOldHash is set, only updates if the stored hash still matches (rehash race guard).</summary>
-    Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken);
+    /// <summary>When expectedOldHash is set, only updates if the stored hash still matches (concurrent-change guard). Returns whether a row was updated.</summary>
+    Task<bool> UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken);
 
     // Invites
     Task<List<UserInvite>> GetInvites(CancellationToken cancellationToken);
     /// <summary>Replaces any existing invite for the same username.</summary>
     Task UpsertInvite(UserInvite invite, CancellationToken cancellationToken);
-    Task DeleteInvite(string username, CancellationToken cancellationToken);
+    /// <summary>Returns the deleted invite's Id, or null when no invite existed (used for audit).</summary>
+    Task<Guid?> DeleteInvite(string username, CancellationToken cancellationToken);
     /// <summary>Atomically consumes (deletes and returns) an unexpired invite. Null when missing or expired.</summary>
     Task<UserInvite?> ConsumeInvite(string token, CancellationToken cancellationToken);
 

--- a/src/Config.DataProvider.Interfaces/IUserDataAccess.cs
+++ b/src/Config.DataProvider.Interfaces/IUserDataAccess.cs
@@ -1,0 +1,65 @@
+using pote.Config.DbModel;
+
+namespace pote.Config.DataProvider.Interfaces;
+
+/// <summary>Result of validating a session token: the session joined with its live user row.</summary>
+public class SessionUser
+{
+    public Guid UserId { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsGuest { get; set; }
+    public DateTime ExpiresUtc { get; set; }
+}
+
+public interface IUserDataAccess
+{
+    // Users
+    /// <summary>All rows including soft-deleted (guest resurrection triggers only on zero).</summary>
+    Task<int> CountUsers(CancellationToken cancellationToken);
+    /// <summary>All users including soft-deleted ones.</summary>
+    Task<List<User>> GetUsers(CancellationToken cancellationToken);
+    /// <summary>Case-insensitive lookup, including soft-deleted users.</summary>
+    Task<User?> GetUserByUsername(string username, CancellationToken cancellationToken);
+    Task<User?> GetUserById(Guid id, CancellationToken cancellationToken);
+    /// <summary>For guest rows the insert is idempotent: losing a duplicate-key race counts as success.</summary>
+    Task InsertUser(User user, CancellationToken cancellationToken);
+    /// <summary>Soft delete plus session/reset revocation. Returns false when blocked (last active admin).</summary>
+    Task<bool> SoftDeleteUser(Guid id, CancellationToken cancellationToken);
+    Task RestoreUser(Guid id, CancellationToken cancellationToken);
+    /// <summary>Only valid on an already soft-deleted row; FKs cascade sessions/resets.</summary>
+    Task PermanentlyDeleteUser(Guid id, CancellationToken cancellationToken);
+    /// <summary>Hard-deletes the guest row; FK cascade revokes guest sessions.</summary>
+    Task HardDeleteGuest(CancellationToken cancellationToken);
+    /// <summary>Returns false when blocked (demoting the last active admin).</summary>
+    Task<bool> UpdateRole(Guid id, string role, CancellationToken cancellationToken);
+    Task UpdateLastLogin(Guid id, DateTime utc, CancellationToken cancellationToken);
+    /// <summary>When expectedOldHash is set, only updates if the stored hash still matches (rehash race guard).</summary>
+    Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken);
+
+    // Invites
+    Task<List<UserInvite>> GetInvites(CancellationToken cancellationToken);
+    /// <summary>Replaces any existing invite for the same username.</summary>
+    Task UpsertInvite(UserInvite invite, CancellationToken cancellationToken);
+    Task DeleteInvite(string username, CancellationToken cancellationToken);
+    /// <summary>Atomically consumes (deletes and returns) an unexpired invite. Null when missing or expired.</summary>
+    Task<UserInvite?> ConsumeInvite(string token, CancellationToken cancellationToken);
+
+    // Password resets
+    /// <summary>Replaces any existing reset for the same user.</summary>
+    Task UpsertReset(PasswordReset reset, CancellationToken cancellationToken);
+    /// <summary>Atomically consumes (deletes and returns) an unexpired reset. Null when missing or expired.</summary>
+    Task<PasswordReset?> ConsumeReset(string token, CancellationToken cancellationToken);
+    Task DeleteResetsForUser(Guid userId, CancellationToken cancellationToken);
+
+    // Sessions
+    Task InsertSession(Session session, CancellationToken cancellationToken);
+    /// <summary>Joins session to user; null when missing, expired, or the user is soft-deleted.</summary>
+    Task<SessionUser?> GetSessionUser(string token, CancellationToken cancellationToken);
+    Task DeleteSession(string token, CancellationToken cancellationToken);
+    Task DeleteSessionsForUser(Guid userId, CancellationToken cancellationToken);
+    Task DeleteOtherSessionsForUser(Guid userId, string keepToken, CancellationToken cancellationToken);
+
+    /// <summary>Removes expired sessions/invites/resets in bounded batches. Expiry stays authoritative at validation regardless.</summary>
+    Task CleanupExpired(CancellationToken cancellationToken);
+}

--- a/src/Config.DataProvider.SqlServer/AuditLogHandler.cs
+++ b/src/Config.DataProvider.SqlServer/AuditLogHandler.cs
@@ -12,22 +12,24 @@ public class AuditLogHandler : IAuditLogHandler
         _connectionFactory = connectionFactory;
     }
 
-    public Task AuditLogConfiguration(string id, string callerIp, string content) => InsertAuditLog("Configuration", id, callerIp, content);
+    public Task AuditLogConfiguration(string id, string callerIp, string? username, string action, string content) => InsertAuditLog("Configuration", id, callerIp, username, action, content);
 
-    public Task AuditLogEnvironment(string id, string callerIp, string content) => InsertAuditLog("Environment", id, callerIp, content);
+    public Task AuditLogEnvironment(string id, string callerIp, string? username, string action, string content) => InsertAuditLog("Environment", id, callerIp, username, action, content);
 
-    public Task AuditLogApplication(string id, string callerIp, string content) => InsertAuditLog("Application", id, callerIp, content);
+    public Task AuditLogApplication(string id, string callerIp, string? username, string action, string content) => InsertAuditLog("Application", id, callerIp, username, action, content);
 
-    public Task AuditLogSettings(string id, string callerIp, string content) => InsertAuditLog("Settings", id, callerIp, content);
+    public Task AuditLogSettings(string id, string callerIp, string? username, string action, string content) => InsertAuditLog("Settings", id, callerIp, username, action, content);
 
-    public Task AuditLogApiKeys(string id, string callerIp, string content) => InsertAuditLog("ApiKeys", id, callerIp, content);
+    public Task AuditLogApiKeys(string id, string callerIp, string? username, string action, string content) => InsertAuditLog("ApiKeys", id, callerIp, username, action, content);
 
-    public Task AuditLogSecrets(string id, string callerIp, string content) => InsertAuditLog("Secrets", id, callerIp, content);
+    public Task AuditLogSecrets(string id, string callerIp, string? username, string action, string content) => InsertAuditLog("Secrets", id, callerIp, username, action, content);
 
-    private async Task InsertAuditLog(string entityType, string entityId, string callerIp, string content)
+    public Task AuditLogUser(string entityId, string callerIp, string? username, string action, string content) => InsertAuditLog("User", entityId, callerIp, username, action, content);
+
+    private async Task InsertAuditLog(string entityType, string entityId, string callerIp, string? username, string action, string content)
     {
         await using var conn = await _connectionFactory.CreateOpenConnection();
-        await conn.ExecuteAsync("INSERT INTO [AuditLog] ([EntityType], [EntityId], [CallerIp], [Content], [CreatedUtc]) VALUES (@entityType, @entityId, @callerIp, @content, GETUTCDATE())",
-            new { entityType, entityId, callerIp, content });
+        await conn.ExecuteAsync("INSERT INTO [AuditLog] ([EntityType], [EntityId], [CallerIp], [Username], [Action], [Content], [CreatedUtc]) VALUES (@entityType, @entityId, @callerIp, @username, @action, @content, GETUTCDATE())",
+            new { entityType, entityId, callerIp, username, action, content });
     }
 }

--- a/src/Config.DataProvider.SqlServer/Config.DataProvider.SqlServer.csproj
+++ b/src/Config.DataProvider.SqlServer/Config.DataProvider.SqlServer.csproj
@@ -5,7 +5,7 @@
 		<RootNamespace>pote.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<AssemblyName>pote.$(MSBuildProjectName)</AssemblyName>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>warnings</Nullable>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Config.DataProvider.SqlServer/CreateScripts/13_AuditLog.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/13_AuditLog.sql
@@ -4,6 +4,8 @@ CREATE TABLE [dbo].[AuditLog] (
     [EntityId]   NVARCHAR(36)  NOT NULL,
     [CallerIp]   NVARCHAR(100) NOT NULL,
     [Content]    NVARCHAR(MAX) NOT NULL,
+    [Username]   NVARCHAR(100) NULL,
+    [Action]     NVARCHAR(50)  NULL,
     [CreatedUtc] DATETIME2(7)  NOT NULL DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_AuditLog] PRIMARY KEY CLUSTERED ([Id])
 );

--- a/src/Config.DataProvider.SqlServer/CreateScripts/15_Users.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/15_Users.sql
@@ -1,0 +1,15 @@
+CREATE TABLE [dbo].[Users] (
+    [Id]           UNIQUEIDENTIFIER NOT NULL,
+    [Username]     NVARCHAR(100) COLLATE Latin1_General_100_CI_AS NOT NULL,
+    [PasswordHash] NVARCHAR(500) NOT NULL,
+    [Role]         NVARCHAR(20)  NOT NULL,
+    [IsGuest]      BIT           NOT NULL DEFAULT 0,
+    [Deleted]      BIT           NOT NULL DEFAULT 0,
+    [CreatedUtc]   DATETIME2(7)  NOT NULL DEFAULT GETUTCDATE(),
+    [LastLoginUtc] DATETIME2(7)  NULL,
+    CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED ([Id]),
+    CONSTRAINT [CK_Users_Role] CHECK ([Role] IN (N'Admin', N'User'))
+);
+
+-- Uniqueness spans live and soft-deleted users (case-insensitive via column collation).
+CREATE UNIQUE INDEX [UX_Users_Username] ON [dbo].[Users]([Username]);

--- a/src/Config.DataProvider.SqlServer/CreateScripts/15_Users.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/15_Users.sql
@@ -2,7 +2,7 @@ CREATE TABLE [dbo].[Users] (
     [Id]           UNIQUEIDENTIFIER NOT NULL,
     [Username]     NVARCHAR(100) COLLATE Latin1_General_100_CI_AS NOT NULL,
     [PasswordHash] NVARCHAR(500) NOT NULL,
-    [Role]         NVARCHAR(20)  NOT NULL,
+    [Role]         NVARCHAR(20) COLLATE Latin1_General_100_BIN2 NOT NULL,
     [IsGuest]      BIT           NOT NULL DEFAULT 0,
     [Deleted]      BIT           NOT NULL DEFAULT 0,
     [CreatedUtc]   DATETIME2(7)  NOT NULL DEFAULT GETUTCDATE(),

--- a/src/Config.DataProvider.SqlServer/CreateScripts/16_UserInvites.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/16_UserInvites.sql
@@ -1,9 +1,9 @@
 -- No FK to Users: an invite targets a username that has no user row yet.
 CREATE TABLE [dbo].[UserInvites] (
     [Id]         UNIQUEIDENTIFIER NOT NULL,
-    [Token]      NVARCHAR(100) NOT NULL,
+    [Token]      NVARCHAR(100) COLLATE Latin1_General_100_BIN2 NOT NULL,
     [Username]   NVARCHAR(100) COLLATE Latin1_General_100_CI_AS NOT NULL,
-    [Role]       NVARCHAR(20)  NOT NULL,
+    [Role]       NVARCHAR(20) COLLATE Latin1_General_100_BIN2 NOT NULL,
     [CreatedBy]  NVARCHAR(100) NOT NULL,
     [ExpiresUtc] DATETIME2(7)  NOT NULL,
     CONSTRAINT [PK_UserInvites] PRIMARY KEY CLUSTERED ([Token]),

--- a/src/Config.DataProvider.SqlServer/CreateScripts/16_UserInvites.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/16_UserInvites.sql
@@ -1,0 +1,15 @@
+-- No FK to Users: an invite targets a username that has no user row yet.
+CREATE TABLE [dbo].[UserInvites] (
+    [Id]         UNIQUEIDENTIFIER NOT NULL,
+    [Token]      NVARCHAR(100) NOT NULL,
+    [Username]   NVARCHAR(100) COLLATE Latin1_General_100_CI_AS NOT NULL,
+    [Role]       NVARCHAR(20)  NOT NULL,
+    [CreatedBy]  NVARCHAR(100) NOT NULL,
+    [ExpiresUtc] DATETIME2(7)  NOT NULL,
+    CONSTRAINT [PK_UserInvites] PRIMARY KEY CLUSTERED ([Token]),
+    CONSTRAINT [CK_UserInvites_Role] CHECK ([Role] IN (N'Admin', N'User'))
+);
+
+-- One active invite per username.
+CREATE UNIQUE INDEX [UX_UserInvites_Username] ON [dbo].[UserInvites]([Username]);
+CREATE INDEX [IX_UserInvites_ExpiresUtc] ON [dbo].[UserInvites]([ExpiresUtc]);

--- a/src/Config.DataProvider.SqlServer/CreateScripts/17_PasswordResets.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/17_PasswordResets.sql
@@ -1,0 +1,12 @@
+CREATE TABLE [dbo].[PasswordResets] (
+    [Id]         UNIQUEIDENTIFIER NOT NULL,
+    [Token]      NVARCHAR(100) NOT NULL,
+    [UserId]     UNIQUEIDENTIFIER NOT NULL,
+    [ExpiresUtc] DATETIME2(7)  NOT NULL,
+    CONSTRAINT [PK_PasswordResets] PRIMARY KEY CLUSTERED ([Token]),
+    CONSTRAINT [FK_PasswordResets_Users] FOREIGN KEY ([UserId]) REFERENCES [dbo].[Users]([Id]) ON DELETE CASCADE
+);
+
+-- One active reset per user.
+CREATE UNIQUE INDEX [UX_PasswordResets_UserId] ON [dbo].[PasswordResets]([UserId]);
+CREATE INDEX [IX_PasswordResets_ExpiresUtc] ON [dbo].[PasswordResets]([ExpiresUtc]);

--- a/src/Config.DataProvider.SqlServer/CreateScripts/17_PasswordResets.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/17_PasswordResets.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [dbo].[PasswordResets] (
     [Id]         UNIQUEIDENTIFIER NOT NULL,
-    [Token]      NVARCHAR(100) NOT NULL,
+    [Token]      NVARCHAR(100) COLLATE Latin1_General_100_BIN2 NOT NULL,
     [UserId]     UNIQUEIDENTIFIER NOT NULL,
     [ExpiresUtc] DATETIME2(7)  NOT NULL,
     CONSTRAINT [PK_PasswordResets] PRIMARY KEY CLUSTERED ([Token]),

--- a/src/Config.DataProvider.SqlServer/CreateScripts/18_Sessions.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/18_Sessions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE [dbo].[Sessions] (
+    [Token]      NVARCHAR(100) NOT NULL,
+    [UserId]     UNIQUEIDENTIFIER NOT NULL,
+    [CreatedUtc] DATETIME2(7)  NOT NULL DEFAULT GETUTCDATE(),
+    [ExpiresUtc] DATETIME2(7)  NOT NULL,
+    CONSTRAINT [PK_Sessions] PRIMARY KEY CLUSTERED ([Token]),
+    CONSTRAINT [FK_Sessions_Users] FOREIGN KEY ([UserId]) REFERENCES [dbo].[Users]([Id]) ON DELETE CASCADE
+);
+
+CREATE INDEX [IX_Sessions_UserId] ON [dbo].[Sessions]([UserId]);
+CREATE INDEX [IX_Sessions_ExpiresUtc] ON [dbo].[Sessions]([ExpiresUtc]);

--- a/src/Config.DataProvider.SqlServer/CreateScripts/18_Sessions.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/18_Sessions.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [dbo].[Sessions] (
-    [Token]      NVARCHAR(100) NOT NULL,
+    [Token]      NVARCHAR(100) COLLATE Latin1_General_100_BIN2 NOT NULL,
     [UserId]     UNIQUEIDENTIFIER NOT NULL,
     [CreatedUtc] DATETIME2(7)  NOT NULL DEFAULT GETUTCDATE(),
     [ExpiresUtc] DATETIME2(7)  NOT NULL,

--- a/src/Config.DataProvider.SqlServer/CreateScripts/19_AlterAuditLog_AddUsernameAndAction.sql
+++ b/src/Config.DataProvider.SqlServer/CreateScripts/19_AlterAuditLog_AddUsernameAndAction.sql
@@ -1,0 +1,13 @@
+-- Idempotent: safe on fresh databases (where 13_AuditLog.sql already created the columns)
+-- and on existing databases being upgraded.
+IF COL_LENGTH('dbo.AuditLog', 'Username') IS NULL
+    ALTER TABLE [dbo].[AuditLog] ADD [Username] NVARCHAR(100) NULL;
+
+IF COL_LENGTH('dbo.AuditLog', 'Action') IS NULL
+    ALTER TABLE [dbo].[AuditLog] ADD [Action] NVARCHAR(50) NULL;
+GO
+
+-- Legacy rows stored the action verb in Content; backfill Action and keep Content as detail.
+UPDATE [dbo].[AuditLog]
+SET [Action] = [Content]
+WHERE [Action] IS NULL AND LEN([Content]) <= 50;

--- a/src/Config.DataProvider.SqlServer/UserDataAccess.cs
+++ b/src/Config.DataProvider.SqlServer/UserDataAccess.cs
@@ -60,10 +60,15 @@ public class UserDataAccess : IUserDataAccess
         }
     }
 
+    /// <summary>
+    /// Serializes every mutation that could violate the last-active-admin rail.
+    /// Plain in-statement EXISTS checks are not enough under READ COMMITTED:
+    /// two concurrent demotions could each see the other admin and both succeed.
+    /// </summary>
+    private const string AcquireAdminRailLock = "EXEC sp_getapplock @Resource = N'ConfigService.AdminRail', @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = 5000;";
+
     public async Task<bool> SoftDeleteUser(Guid id, CancellationToken cancellationToken)
     {
-        // The last-active-admin invariant is re-checked inside the statement so
-        // concurrent deletions/demotions cannot strand the system without an admin.
         const string sql = """
             UPDATE [Users] SET [Deleted] = 1
             WHERE [Id] = @id AND [Deleted] = 0
@@ -73,6 +78,7 @@ public class UserDataAccess : IUserDataAccess
             """;
         await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
         await using var tx = await conn.BeginTransactionAsync(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(AcquireAdminRailLock, transaction: tx, cancellationToken: cancellationToken));
         var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new { id }, tx, cancellationToken: cancellationToken));
         if (rows == 1)
         {
@@ -114,7 +120,10 @@ public class UserDataAccess : IUserDataAccess
                     WHERE u2.[Role] = N'Admin' AND u2.[Deleted] = 0 AND u2.[Id] <> @id))
             """;
         await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
-        var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new { id, role }, cancellationToken: cancellationToken));
+        await using var tx = await conn.BeginTransactionAsync(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(AcquireAdminRailLock, transaction: tx, cancellationToken: cancellationToken));
+        var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new { id, role }, tx, cancellationToken: cancellationToken));
+        await tx.CommitAsync(cancellationToken);
         return rows == 1;
     }
 
@@ -125,14 +134,15 @@ public class UserDataAccess : IUserDataAccess
             "UPDATE [Users] SET [LastLoginUtc] = @utc WHERE [Id] = @id", new { id, utc }, cancellationToken: cancellationToken));
     }
 
-    public async Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken)
+    public async Task<bool> UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken)
     {
         const string sql = """
             UPDATE [Users] SET [PasswordHash] = @newHash
             WHERE [Id] = @id AND (@expectedOldHash IS NULL OR [PasswordHash] = @expectedOldHash)
             """;
         await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
-        await conn.ExecuteAsync(new CommandDefinition(sql, new { id, newHash, expectedOldHash }, cancellationToken: cancellationToken));
+        var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new { id, newHash, expectedOldHash }, cancellationToken: cancellationToken));
+        return rows == 1;
     }
 
     public async Task<List<UserInvite>> GetInvites(CancellationToken cancellationToken)
@@ -156,11 +166,11 @@ public class UserDataAccess : IUserDataAccess
         await tx.CommitAsync(cancellationToken);
     }
 
-    public async Task DeleteInvite(string username, CancellationToken cancellationToken)
+    public async Task<Guid?> DeleteInvite(string username, CancellationToken cancellationToken)
     {
         await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
-        await conn.ExecuteAsync(new CommandDefinition(
-            "DELETE FROM [UserInvites] WHERE [Username] = @username", new { username }, cancellationToken: cancellationToken));
+        return await conn.QueryFirstOrDefaultAsync<Guid?>(new CommandDefinition(
+            "DELETE FROM [UserInvites] OUTPUT DELETED.[Id] WHERE [Username] = @username", new { username }, cancellationToken: cancellationToken));
     }
 
     public async Task<UserInvite?> ConsumeInvite(string token, CancellationToken cancellationToken)

--- a/src/Config.DataProvider.SqlServer/UserDataAccess.cs
+++ b/src/Config.DataProvider.SqlServer/UserDataAccess.cs
@@ -1,0 +1,264 @@
+using Dapper;
+using Microsoft.Data.SqlClient;
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.DataProvider.SqlServer;
+
+public class UserDataAccess : IUserDataAccess
+{
+    private readonly SqlConnectionFactory _connectionFactory;
+
+    public UserDataAccess(SqlConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<int> CountUsers(CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        return await conn.ExecuteScalarAsync<int>(new CommandDefinition(
+            "SELECT COUNT(*) FROM [Users]", cancellationToken: cancellationToken));
+    }
+
+    public async Task<List<User>> GetUsers(CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        var users = await conn.QueryAsync<User>(new CommandDefinition(
+            "SELECT * FROM [Users] ORDER BY [Username]", cancellationToken: cancellationToken));
+        return users.ToList();
+    }
+
+    public async Task<User?> GetUserByUsername(string username, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        return await conn.QueryFirstOrDefaultAsync<User>(new CommandDefinition(
+            "SELECT * FROM [Users] WHERE [Username] = @username", new { username }, cancellationToken: cancellationToken));
+    }
+
+    public async Task<User?> GetUserById(Guid id, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        return await conn.QueryFirstOrDefaultAsync<User>(new CommandDefinition(
+            "SELECT * FROM [Users] WHERE [Id] = @id", new { id }, cancellationToken: cancellationToken));
+    }
+
+    public async Task InsertUser(User user, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            INSERT INTO [Users] ([Id], [Username], [PasswordHash], [Role], [IsGuest], [Deleted], [CreatedUtc], [LastLoginUtc])
+            VALUES (@Id, @Username, @PasswordHash, @Role, @IsGuest, @Deleted, @CreatedUtc, @LastLoginUtc)
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        try
+        {
+            await conn.ExecuteAsync(new CommandDefinition(sql, user, cancellationToken: cancellationToken));
+        }
+        catch (SqlException ex) when (user.IsGuest && ex.Number is 2601 or 2627)
+        {
+            // Multi-instance guest bootstrap: losing the duplicate-key race is success.
+        }
+    }
+
+    public async Task<bool> SoftDeleteUser(Guid id, CancellationToken cancellationToken)
+    {
+        // The last-active-admin invariant is re-checked inside the statement so
+        // concurrent deletions/demotions cannot strand the system without an admin.
+        const string sql = """
+            UPDATE [Users] SET [Deleted] = 1
+            WHERE [Id] = @id AND [Deleted] = 0
+              AND ([Role] <> N'Admin' OR EXISTS (
+                    SELECT 1 FROM [Users] u2
+                    WHERE u2.[Role] = N'Admin' AND u2.[Deleted] = 0 AND u2.[Id] <> @id))
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(cancellationToken);
+        var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new { id }, tx, cancellationToken: cancellationToken));
+        if (rows == 1)
+        {
+            await conn.ExecuteAsync(new CommandDefinition("DELETE FROM [Sessions] WHERE [UserId] = @id", new { id }, tx, cancellationToken: cancellationToken));
+            await conn.ExecuteAsync(new CommandDefinition("DELETE FROM [PasswordResets] WHERE [UserId] = @id", new { id }, tx, cancellationToken: cancellationToken));
+        }
+        await tx.CommitAsync(cancellationToken);
+        return rows == 1;
+    }
+
+    public async Task RestoreUser(Guid id, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "UPDATE [Users] SET [Deleted] = 0 WHERE [Id] = @id AND [Deleted] = 1", new { id }, cancellationToken: cancellationToken));
+    }
+
+    public async Task PermanentlyDeleteUser(Guid id, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [Users] WHERE [Id] = @id AND [Deleted] = 1", new { id }, cancellationToken: cancellationToken));
+    }
+
+    public async Task HardDeleteGuest(CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [Users] WHERE [IsGuest] = 1", cancellationToken: cancellationToken));
+    }
+
+    public async Task<bool> UpdateRole(Guid id, string role, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            UPDATE [Users] SET [Role] = @role
+            WHERE [Id] = @id AND [Deleted] = 0
+              AND (@role = N'Admin' OR [Role] <> N'Admin' OR EXISTS (
+                    SELECT 1 FROM [Users] u2
+                    WHERE u2.[Role] = N'Admin' AND u2.[Deleted] = 0 AND u2.[Id] <> @id))
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new { id, role }, cancellationToken: cancellationToken));
+        return rows == 1;
+    }
+
+    public async Task UpdateLastLogin(Guid id, DateTime utc, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "UPDATE [Users] SET [LastLoginUtc] = @utc WHERE [Id] = @id", new { id, utc }, cancellationToken: cancellationToken));
+    }
+
+    public async Task UpdatePasswordHash(Guid id, string newHash, string? expectedOldHash, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            UPDATE [Users] SET [PasswordHash] = @newHash
+            WHERE [Id] = @id AND (@expectedOldHash IS NULL OR [PasswordHash] = @expectedOldHash)
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(sql, new { id, newHash, expectedOldHash }, cancellationToken: cancellationToken));
+    }
+
+    public async Task<List<UserInvite>> GetInvites(CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        var invites = await conn.QueryAsync<UserInvite>(new CommandDefinition(
+            "SELECT * FROM [UserInvites] WHERE [ExpiresUtc] > GETUTCDATE() ORDER BY [Username]", cancellationToken: cancellationToken));
+        return invites.ToList();
+    }
+
+    public async Task UpsertInvite(UserInvite invite, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            DELETE FROM [UserInvites] WHERE [Username] = @Username;
+            INSERT INTO [UserInvites] ([Id], [Token], [Username], [Role], [CreatedBy], [ExpiresUtc])
+            VALUES (@Id, @Token, @Username, @Role, @CreatedBy, @ExpiresUtc);
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(sql, invite, tx, cancellationToken: cancellationToken));
+        await tx.CommitAsync(cancellationToken);
+    }
+
+    public async Task DeleteInvite(string username, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [UserInvites] WHERE [Username] = @username", new { username }, cancellationToken: cancellationToken));
+    }
+
+    public async Task<UserInvite?> ConsumeInvite(string token, CancellationToken cancellationToken)
+    {
+        // Atomic single-use consumption: concurrent redemptions cannot both get a row.
+        const string sql = """
+            DELETE FROM [UserInvites]
+            OUTPUT DELETED.[Id], DELETED.[Token], DELETED.[Username], DELETED.[Role], DELETED.[CreatedBy], DELETED.[ExpiresUtc]
+            WHERE [Token] = @token AND [ExpiresUtc] > GETUTCDATE()
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        return await conn.QueryFirstOrDefaultAsync<UserInvite>(new CommandDefinition(sql, new { token }, cancellationToken: cancellationToken));
+    }
+
+    public async Task UpsertReset(PasswordReset reset, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            DELETE FROM [PasswordResets] WHERE [UserId] = @UserId;
+            INSERT INTO [PasswordResets] ([Id], [Token], [UserId], [ExpiresUtc])
+            VALUES (@Id, @Token, @UserId, @ExpiresUtc);
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await using var tx = await conn.BeginTransactionAsync(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(sql, reset, tx, cancellationToken: cancellationToken));
+        await tx.CommitAsync(cancellationToken);
+    }
+
+    public async Task<PasswordReset?> ConsumeReset(string token, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            DELETE FROM [PasswordResets]
+            OUTPUT DELETED.[Id], DELETED.[Token], DELETED.[UserId], DELETED.[ExpiresUtc]
+            WHERE [Token] = @token AND [ExpiresUtc] > GETUTCDATE()
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        return await conn.QueryFirstOrDefaultAsync<PasswordReset>(new CommandDefinition(sql, new { token }, cancellationToken: cancellationToken));
+    }
+
+    public async Task DeleteResetsForUser(Guid userId, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [PasswordResets] WHERE [UserId] = @userId", new { userId }, cancellationToken: cancellationToken));
+    }
+
+    public async Task InsertSession(Session session, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "INSERT INTO [Sessions] ([Token], [UserId], [CreatedUtc], [ExpiresUtc]) VALUES (@Token, @UserId, @CreatedUtc, @ExpiresUtc)",
+            session, cancellationToken: cancellationToken));
+    }
+
+    public async Task<SessionUser?> GetSessionUser(string token, CancellationToken cancellationToken)
+    {
+        // Joined to the live user row: role changes, soft deletes, and hard deletes
+        // take effect on the next request. Expiry is authoritative here regardless of cleanup.
+        const string sql = """
+            SELECT u.[Id] AS UserId, u.[Username], u.[Role], u.[IsGuest], s.[ExpiresUtc]
+            FROM [Sessions] s
+            INNER JOIN [Users] u ON u.[Id] = s.[UserId]
+            WHERE s.[Token] = @token AND s.[ExpiresUtc] > GETUTCDATE() AND u.[Deleted] = 0
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        return await conn.QueryFirstOrDefaultAsync<SessionUser>(new CommandDefinition(sql, new { token }, cancellationToken: cancellationToken));
+    }
+
+    public async Task DeleteSession(string token, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [Sessions] WHERE [Token] = @token", new { token }, cancellationToken: cancellationToken));
+    }
+
+    public async Task DeleteSessionsForUser(Guid userId, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [Sessions] WHERE [UserId] = @userId", new { userId }, cancellationToken: cancellationToken));
+    }
+
+    public async Task DeleteOtherSessionsForUser(Guid userId, string keepToken, CancellationToken cancellationToken)
+    {
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "DELETE FROM [Sessions] WHERE [UserId] = @userId AND [Token] <> @keepToken",
+            new { userId, keepToken }, cancellationToken: cancellationToken));
+    }
+
+    public async Task CleanupExpired(CancellationToken cancellationToken)
+    {
+        // Bounded batches so a large backlog on a quiet system cannot block the login path.
+        const string sql = """
+            DELETE TOP (1000) FROM [Sessions] WHERE [ExpiresUtc] < GETUTCDATE();
+            DELETE TOP (1000) FROM [UserInvites] WHERE [ExpiresUtc] < GETUTCDATE();
+            DELETE TOP (1000) FROM [PasswordResets] WHERE [ExpiresUtc] < GETUTCDATE();
+            """;
+        await using var conn = await _connectionFactory.CreateOpenConnection(cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(sql, cancellationToken: cancellationToken));
+    }
+}

--- a/src/Config.DbModel/PasswordReset.cs
+++ b/src/Config.DbModel/PasswordReset.cs
@@ -1,0 +1,9 @@
+namespace pote.Config.DbModel;
+
+public class PasswordReset
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Token { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public DateTime ExpiresUtc { get; set; }
+}

--- a/src/Config.DbModel/Session.cs
+++ b/src/Config.DbModel/Session.cs
@@ -1,0 +1,9 @@
+namespace pote.Config.DbModel;
+
+public class Session
+{
+    public string Token { get; set; } = string.Empty;
+    public Guid UserId { get; set; }
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public DateTime ExpiresUtc { get; set; }
+}

--- a/src/Config.DbModel/User.cs
+++ b/src/Config.DbModel/User.cs
@@ -1,0 +1,21 @@
+namespace pote.Config.DbModel;
+
+public class User
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Username { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public string Role { get; set; } = UserRoles.User;
+    public bool IsGuest { get; set; }
+    public bool Deleted { get; set; }
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? LastLoginUtc { get; set; }
+}
+
+public static class UserRoles
+{
+    public const string Admin = "Admin";
+    public const string User = "User";
+
+    public static bool IsValid(string role) => role is Admin or User;
+}

--- a/src/Config.DbModel/UserInvite.cs
+++ b/src/Config.DbModel/UserInvite.cs
@@ -1,0 +1,11 @@
+namespace pote.Config.DbModel;
+
+public class UserInvite
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Token { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Role { get; set; } = UserRoles.User;
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime ExpiresUtc { get; set; }
+}

--- a/src/Config.UnitTests/Auth/AuthServiceTests.cs
+++ b/src/Config.UnitTests/Auth/AuthServiceTests.cs
@@ -196,12 +196,27 @@ public class AuthServiceTests
     {
         var user = MakeUser("anna", ValidPassword);
         _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        _users.UpdatePasswordHash(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(true);
 
         var ok = await _sut.ChangePassword(user.Id, ValidPassword, "NewPassword1!xxxx", "keep-token", CancellationToken.None);
 
         Assert.IsTrue(ok);
-        await _users.Received(1).UpdatePasswordHash(user.Id, Arg.Any<string>(), Arg.Is((string?)null), Arg.Any<CancellationToken>());
+        // Guarded by the current hash so concurrent changes cannot both win.
+        await _users.Received(1).UpdatePasswordHash(user.Id, Arg.Any<string>(), Arg.Is(user.PasswordHash), Arg.Any<CancellationToken>());
         await _users.Received(1).DeleteOtherSessionsForUser(user.Id, "keep-token", Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ChangePassword_ConcurrentChangeWonTheRace_ReturnsFalse()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        _users.UpdatePasswordHash(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        var ok = await _sut.ChangePassword(user.Id, ValidPassword, "NewPassword1!xxxx", "keep-token", CancellationToken.None);
+
+        Assert.IsFalse(ok);
+        await _users.DidNotReceive().DeleteOtherSessionsForUser(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Test]

--- a/src/Config.UnitTests/Auth/AuthServiceTests.cs
+++ b/src/Config.UnitTests/Auth/AuthServiceTests.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using pote.Config.Admin.Api.Auth;
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.UnitTests.Auth;
+
+[TestFixture]
+public class AuthServiceTests
+{
+    private IUserDataAccess _users = null!;
+    private AuthService _sut = null!;
+    private readonly PasswordHasher<User> _hasher = new();
+
+    private const string ValidPassword = "CorrectHorse1!Battery";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _users = Substitute.For<IUserDataAccess>();
+        _sut = new AuthService(_users, new PasswordHasher<User>(), new AuthSettings(),
+            Substitute.For<ILogger<AuthService>>());
+    }
+
+    private User MakeUser(string username, string password, string role = UserRoles.Admin, bool isGuest = false, bool deleted = false)
+    {
+        var user = new User { Username = username, Role = role, IsGuest = isGuest, Deleted = deleted };
+        user.PasswordHash = _hasher.HashPassword(user, password);
+        return user;
+    }
+
+    // ---------- Login ----------
+
+    [Test]
+    public async Task Login_ValidRealUser_ReturnsSessionAndDeletesGuest()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _sut.Login("anna", ValidPassword, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("anna", result!.Username);
+        Assert.AreEqual(UserRoles.Admin, result.Role);
+        Assert.IsFalse(result.IsGuest);
+        Assert.IsNotEmpty(result.Token);
+        Assert.Greater(result.ExpiresUtc, DateTime.UtcNow.AddHours(7));
+        await _users.Received(1).HardDeleteGuest(Arg.Any<CancellationToken>());
+        await _users.Received(1).InsertSession(Arg.Is<Session>(s => s.UserId == user.Id && s.Token == result.Token), Arg.Any<CancellationToken>());
+        await _users.Received(1).UpdateLastLogin(user.Id, Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Login_GuestUser_DoesNotDeleteGuest()
+    {
+        var guest = MakeUser("guest", "guest", isGuest: true);
+        _users.GetUserByUsername("guest", Arg.Any<CancellationToken>()).Returns(guest);
+
+        var result = await _sut.Login("guest", "guest", CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result!.IsGuest);
+        await _users.DidNotReceive().HardDeleteGuest(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Login_UnknownUser_ReturnsNull()
+    {
+        _users.GetUserByUsername("nobody", Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await _sut.Login("nobody", ValidPassword, CancellationToken.None);
+
+        Assert.IsNull(result);
+        await _users.DidNotReceive().InsertSession(Arg.Any<Session>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Login_WrongPassword_ReturnsNull()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _sut.Login("anna", "WrongPassword1!xx", CancellationToken.None);
+
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public async Task Login_SoftDeletedUser_ReturnsNull()
+    {
+        var user = MakeUser("anna", ValidPassword, deleted: true);
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _sut.Login("anna", ValidPassword, CancellationToken.None);
+
+        Assert.IsNull(result);
+    }
+
+    // ---------- Redeem: invites ----------
+
+    [Test]
+    public async Task Redeem_ValidInvite_CreatesUserWithInviteRoleAndLogsIn()
+    {
+        _users.ConsumeInvite("tok", Arg.Any<CancellationToken>())
+            .Returns(new UserInvite { Username = "anna", Role = UserRoles.User, ExpiresUtc = DateTime.UtcNow.AddDays(1) });
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await _sut.Redeem("tok", ValidPassword, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("anna", result!.Username);
+        Assert.AreEqual(UserRoles.User, result.Role);
+        await _users.Received(1).InsertUser(Arg.Is<User>(u => u.Username == "anna" && u.Role == UserRoles.User && !u.IsGuest), Arg.Any<CancellationToken>());
+        await _users.Received(1).HardDeleteGuest(Arg.Any<CancellationToken>());
+        await _users.Received(1).InsertSession(Arg.Any<Session>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Redeem_InviteUsernameTakenMeanwhile_ReturnsNull()
+    {
+        _users.ConsumeInvite("tok", Arg.Any<CancellationToken>())
+            .Returns(new UserInvite { Username = "anna", Role = UserRoles.User });
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(MakeUser("anna", ValidPassword));
+
+        var result = await _sut.Redeem("tok", ValidPassword, CancellationToken.None);
+
+        Assert.IsNull(result);
+        await _users.DidNotReceive().InsertUser(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Redeem_InvalidPassword_ReturnsNullWithoutConsumingToken()
+    {
+        var result = await _sut.Redeem("tok", "weak", CancellationToken.None);
+
+        Assert.IsNull(result);
+        await _users.DidNotReceive().ConsumeInvite(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _users.DidNotReceive().ConsumeReset(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // ---------- Redeem: resets ----------
+
+    [Test]
+    public async Task Redeem_ValidReset_UpdatesHashRevokesSessionsAndLogsIn()
+    {
+        var user = MakeUser("anna", "OldPassword1!xxxx");
+        _users.ConsumeInvite("tok", Arg.Any<CancellationToken>()).Returns((UserInvite?)null);
+        _users.ConsumeReset("tok", Arg.Any<CancellationToken>())
+            .Returns(new PasswordReset { UserId = user.Id, ExpiresUtc = DateTime.UtcNow.AddDays(1) });
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _sut.Redeem("tok", ValidPassword, CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("anna", result!.Username);
+        await _users.Received(1).UpdatePasswordHash(user.Id, Arg.Any<string>(), Arg.Is((string?)null), Arg.Any<CancellationToken>());
+        await _users.Received(1).DeleteSessionsForUser(user.Id, Arg.Any<CancellationToken>());
+        await _users.Received(1).InsertSession(Arg.Any<Session>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Redeem_ResetForDeletedUser_ReturnsNull()
+    {
+        var user = MakeUser("anna", ValidPassword, deleted: true);
+        _users.ConsumeInvite("tok", Arg.Any<CancellationToken>()).Returns((UserInvite?)null);
+        _users.ConsumeReset("tok", Arg.Any<CancellationToken>()).Returns(new PasswordReset { UserId = user.Id });
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _sut.Redeem("tok", ValidPassword, CancellationToken.None);
+
+        Assert.IsNull(result);
+        await _users.DidNotReceive().UpdatePasswordHash(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Redeem_UnknownToken_ReturnsNull()
+    {
+        _users.ConsumeInvite("tok", Arg.Any<CancellationToken>()).Returns((UserInvite?)null);
+        _users.ConsumeReset("tok", Arg.Any<CancellationToken>()).Returns((PasswordReset?)null);
+
+        var result = await _sut.Redeem("tok", ValidPassword, CancellationToken.None);
+
+        Assert.IsNull(result);
+    }
+
+    // ---------- Change password ----------
+
+    [Test]
+    public async Task ChangePassword_ValidCurrent_UpdatesAndRevokesOtherSessions()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var ok = await _sut.ChangePassword(user.Id, ValidPassword, "NewPassword1!xxxx", "keep-token", CancellationToken.None);
+
+        Assert.IsTrue(ok);
+        await _users.Received(1).UpdatePasswordHash(user.Id, Arg.Any<string>(), Arg.Is((string?)null), Arg.Any<CancellationToken>());
+        await _users.Received(1).DeleteOtherSessionsForUser(user.Id, "keep-token", Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ChangePassword_WrongCurrent_ReturnsFalse()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var ok = await _sut.ChangePassword(user.Id, "WrongCurrent1!xxx", "NewPassword1!xxxx", "keep", CancellationToken.None);
+
+        Assert.IsFalse(ok);
+        await _users.DidNotReceive().UpdatePasswordHash(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ChangePassword_WeakNewPassword_ReturnsFalse()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var ok = await _sut.ChangePassword(user.Id, ValidPassword, "weak", "keep", CancellationToken.None);
+
+        Assert.IsFalse(ok);
+    }
+
+    // ---------- Guest bootstrap / first user ----------
+
+    [Test]
+    public async Task EnsureGuestSeeded_EmptyStore_InsertsGuestAdmin()
+    {
+        _users.CountUsers(Arg.Any<CancellationToken>()).Returns(0);
+
+        await _sut.EnsureGuestSeeded(CancellationToken.None);
+
+        await _users.Received(1).InsertUser(Arg.Is<User>(u =>
+            u.Username == "guest" && u.IsGuest && u.Role == UserRoles.Admin && u.PasswordHash.Length > 0), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task EnsureGuestSeeded_NonEmptyStore_DoesNothing()
+    {
+        _users.CountUsers(Arg.Any<CancellationToken>()).Returns(3);
+
+        await _sut.EnsureGuestSeeded(CancellationToken.None);
+
+        await _users.DidNotReceive().InsertUser(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task CreateFirstUser_CreatesAdminAndLogsIn()
+    {
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await _sut.CreateFirstUser("anna", ValidPassword, CancellationToken.None);
+
+        Assert.AreEqual("anna", result.Username);
+        Assert.AreEqual(UserRoles.Admin, result.Role);
+        Assert.IsFalse(result.IsGuest);
+        await _users.Received(1).InsertUser(Arg.Is<User>(u => u.Username == "anna" && u.Role == UserRoles.Admin && !u.IsGuest), Arg.Any<CancellationToken>());
+        // The auto-login counts as the first real login, which deletes the guest user.
+        await _users.Received(1).HardDeleteGuest(Arg.Any<CancellationToken>());
+        await _users.Received(1).InsertSession(Arg.Any<Session>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public void CreateFirstUser_UsernameTaken_Throws()
+    {
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(MakeUser("anna", ValidPassword));
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => _sut.CreateFirstUser("anna", ValidPassword, CancellationToken.None));
+    }
+
+    [Test]
+    public void CreateFirstUser_WeakPassword_Throws()
+    {
+        Assert.ThrowsAsync<InvalidOperationException>(() => _sut.CreateFirstUser("anna", "weak", CancellationToken.None));
+    }
+}

--- a/src/Config.UnitTests/Auth/PasswordPolicyTests.cs
+++ b/src/Config.UnitTests/Auth/PasswordPolicyTests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using pote.Config.Admin.Api.Auth;
+
+namespace pote.Config.UnitTests.Auth;
+
+[TestFixture]
+public class PasswordPolicyTests
+{
+    [TestCase("Abcdefgh1!abcdef")] // exactly 16, all classes
+    [TestCase("LongerPassword1!WithMoreChars")]
+    public void Validate_ValidPasswords_ReturnsNull(string password)
+    {
+        Assert.IsNull(PasswordPolicy.Validate(password));
+    }
+
+    [TestCase("Ab1!x")]                    // too short
+    [TestCase("abcdefgh1!abcdef")]         // no uppercase
+    [TestCase("ABCDEFGH1!ABCDEF")]         // no lowercase
+    [TestCase("Abcdefgh!abcdefg")]         // no digit
+    [TestCase("Abcdefgh1abcdefg")]         // no special
+    [TestCase("")]                         // empty
+    public void Validate_InvalidPasswords_ReturnsReason(string password)
+    {
+        Assert.IsNotNull(PasswordPolicy.Validate(password));
+    }
+
+    [Test]
+    public void Validate_TooLong_ReturnsReason()
+    {
+        var password = "Aa1!" + new string('x', 130);
+        Assert.IsNotNull(PasswordPolicy.Validate(password));
+    }
+}

--- a/src/Config.UnitTests/Auth/SessionAuthenticationHandlerTests.cs
+++ b/src/Config.UnitTests/Auth/SessionAuthenticationHandlerTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
+using pote.Config.Admin.Api.Auth;
+using pote.Config.DataProvider.Interfaces;
+
+namespace pote.Config.UnitTests.Auth;
+
+[TestFixture]
+public class SessionAuthenticationHandlerTests
+{
+    private IUserDataAccess _users = null!;
+    private SessionAuthenticationHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _users = Substitute.For<IUserDataAccess>();
+        var options = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        options.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        _handler = new SessionAuthenticationHandler(options, loggerFactory, UrlEncoder.Default, _users);
+    }
+
+    private async Task<AuthenticateResult> Authenticate(string? authorizationHeader)
+    {
+        var context = new DefaultHttpContext();
+        if (authorizationHeader != null)
+            context.Request.Headers.Authorization = authorizationHeader;
+        var scheme = new AuthenticationScheme(AuthPolicies.SchemeName, null, typeof(SessionAuthenticationHandler));
+        await _handler.InitializeAsync(scheme, context);
+        return await _handler.AuthenticateAsync();
+    }
+
+    [Test]
+    public async Task ValidToken_ProducesNameRoleAndUserIdClaims()
+    {
+        var userId = Guid.NewGuid();
+        _users.GetSessionUser("tok123", Arg.Any<CancellationToken>()).Returns(new SessionUser
+        {
+            UserId = userId, Username = "anna", Role = "Admin", IsGuest = false, ExpiresUtc = DateTime.UtcNow.AddHours(1)
+        });
+
+        var result = await Authenticate("Bearer tok123");
+
+        Assert.IsTrue(result.Succeeded);
+        var principal = result.Principal!;
+        Assert.AreEqual("anna", principal.Identity!.Name);
+        Assert.IsTrue(principal.IsInRole("Admin"));
+        Assert.AreEqual(userId.ToString(), principal.FindFirstValue(AuthPolicies.UserIdClaim));
+        Assert.IsNull(principal.FindFirst(AuthPolicies.GuestClaim));
+    }
+
+    [Test]
+    public async Task GuestSession_ProducesGuestClaim()
+    {
+        _users.GetSessionUser("tok123", Arg.Any<CancellationToken>()).Returns(new SessionUser
+        {
+            UserId = Guid.NewGuid(), Username = "guest", Role = "Admin", IsGuest = true, ExpiresUtc = DateTime.UtcNow.AddHours(1)
+        });
+
+        var result = await Authenticate("Bearer tok123");
+
+        Assert.IsTrue(result.Succeeded);
+        Assert.IsNotNull(result.Principal!.FindFirst(AuthPolicies.GuestClaim));
+    }
+
+    [Test]
+    public async Task UnknownOrExpiredToken_Fails()
+    {
+        _users.GetSessionUser("tok123", Arg.Any<CancellationToken>()).Returns((SessionUser?)null);
+
+        var result = await Authenticate("Bearer tok123");
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.Failure);
+    }
+
+    [Test]
+    public async Task MissingHeader_NoResult()
+    {
+        var result = await Authenticate(null);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsTrue(result.None);
+    }
+
+    [Test]
+    public async Task NonBearerHeader_NoResult()
+    {
+        var result = await Authenticate("Basic abc");
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsTrue(result.None);
+    }
+}

--- a/src/Config.UnitTests/Auth/UsernameRulesTests.cs
+++ b/src/Config.UnitTests/Auth/UsernameRulesTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using pote.Config.Admin.Api.Auth;
+
+namespace pote.Config.UnitTests.Auth;
+
+[TestFixture]
+public class UsernameRulesTests
+{
+    [TestCase("anna")]
+    [TestCase("anna.smith@example.com")]
+    [TestCase("A-b_c.d@e")]
+    [TestCase("x")]
+    public void Validate_ValidUsernames_ReturnsNull(string username)
+    {
+        Assert.IsNull(UsernameRules.Validate(username, out _));
+    }
+
+    [Test]
+    public void Validate_Trims_ReturnsTrimmed()
+    {
+        Assert.IsNull(UsernameRules.Validate("  anna  ", out var trimmed));
+        Assert.AreEqual("anna", trimmed);
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("has space")]
+    [TestCase("slash/name")]
+    [TestCase("question?name")]
+    [TestCase("semi;name")]
+    [TestCase("tab\tname")]
+    public void Validate_InvalidUsernames_ReturnsReason(string username)
+    {
+        Assert.IsNotNull(UsernameRules.Validate(username, out _));
+    }
+
+    [TestCase("guest")]
+    [TestCase("GUEST")]
+    [TestCase("Guest")]
+    [TestCase(" guest ")]
+    public void Validate_GuestReserved_CaseInsensitive(string username)
+    {
+        Assert.IsNotNull(UsernameRules.Validate(username, out _));
+    }
+
+    [Test]
+    public void Validate_TooLong_ReturnsReason()
+    {
+        Assert.IsNotNull(UsernameRules.Validate(new string('a', 101), out _));
+    }
+
+    [Test]
+    public void Validate_MaxLength_IsValid()
+    {
+        Assert.IsNull(UsernameRules.Validate(new string('a', 100), out _));
+    }
+}

--- a/src/Config.UnitTests/ConfigurationsControllerTests.cs
+++ b/src/Config.UnitTests/ConfigurationsControllerTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -27,7 +27,7 @@ public class ConfigurationsControllerTests
         _dataProvider = Substitute.For<IAdminDataProvider>();
         var memoryCache = new MemoryCache(new MemoryCacheOptions());
         var auditLogHandler = Substitute.For<IAuditLogHandler>();
-        auditLogHandler.AuditLogConfiguration(default!, default!, default!).ReturnsForAnyArgs(Task.CompletedTask);
+        auditLogHandler.AuditLogConfiguration(default!, default!, default, default!, default!).ReturnsForAnyArgs(Task.CompletedTask);
         _controller = new ConfigurationsController(logger, _dataProvider, memoryCache, auditLogHandler);
         _controller.ControllerContext = new ControllerContext
         {

--- a/src/Config.UnitTests/Controllers/AuthControllerTests.cs
+++ b/src/Config.UnitTests/Controllers/AuthControllerTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using pote.Config.Admin.Api.Auth;
+using pote.Config.Admin.Api.Controllers;
+using pote.Config.Admin.Api.Model.RequestResponse;
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.UnitTests.Controllers;
+
+[TestFixture]
+public class AuthControllerTests
+{
+    private IUserDataAccess _users = null!;
+    private AuthController _controller = null!;
+    private readonly PasswordHasher<User> _hasher = new();
+
+    private const string ValidPassword = "CorrectHorse1!Battery";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _users = Substitute.For<IUserDataAccess>();
+        var authService = new AuthService(_users, new PasswordHasher<User>(), new AuthSettings(),
+            Substitute.For<ILogger<AuthService>>());
+        _controller = new AuthController(Substitute.For<ILogger<AuthController>>(), authService, _users,
+            new LocalAuthProviderSetup(), Substitute.For<IAuditLogHandler>());
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+    }
+
+    private User MakeUser(string username, string password)
+    {
+        var user = new User { Username = username, Role = UserRoles.Admin };
+        user.PasswordHash = _hasher.HashPassword(user, password);
+        return user;
+    }
+
+    private void SetAuthenticatedUser(Guid userId, string username, string sessionToken)
+    {
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, username),
+            new Claim(AuthPolicies.UserIdClaim, userId.ToString()),
+            new Claim("sessionToken", sessionToken)
+        }, "test");
+        _controller.HttpContext.User = new ClaimsPrincipal(identity);
+    }
+
+    [Test]
+    public async Task Login_Success_ReturnsTokenAndNoStoreHeader()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _controller.Login(new LoginRequest { Username = "anna", Password = ValidPassword }, CancellationToken.None);
+
+        var ok = result.Result as OkObjectResult;
+        Assert.IsNotNull(ok);
+        var response = (LoginResponse)ok!.Value!;
+        Assert.AreEqual("anna", response.Username);
+        Assert.IsNotEmpty(response.Token);
+        Assert.AreEqual("no-store", _controller.Response.Headers.CacheControl.ToString());
+    }
+
+    [Test]
+    public async Task Login_Failure_ReturnsPlain401()
+    {
+        _users.GetUserByUsername("nobody", Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await _controller.Login(new LoginRequest { Username = "nobody", Password = ValidPassword }, CancellationToken.None);
+
+        Assert.IsInstanceOf<UnauthorizedResult>(result.Result);
+    }
+
+    [Test]
+    public async Task Login_Failure_TakesAtLeastMinimumDuration()
+    {
+        _users.GetUserByUsername("nobody", Arg.Any<CancellationToken>()).Returns((User?)null);
+        var started = DateTime.UtcNow;
+
+        await _controller.Login(new LoginRequest { Username = "nobody", Password = ValidPassword }, CancellationToken.None);
+
+        Assert.GreaterOrEqual(DateTime.UtcNow - started, AuthController.MinimumFailureDuration - TimeSpan.FromMilliseconds(50));
+    }
+
+    [Test]
+    public async Task Redeem_UnknownToken_ReturnsGeneric400()
+    {
+        _users.ConsumeInvite("tok", Arg.Any<CancellationToken>()).Returns((UserInvite?)null);
+        _users.ConsumeReset("tok", Arg.Any<CancellationToken>()).Returns((PasswordReset?)null);
+
+        var result = await _controller.Redeem(new RedeemRequest { Token = "tok", Password = ValidPassword }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result.Result);
+    }
+
+    [Test]
+    public async Task Logout_DeletesSession()
+    {
+        SetAuthenticatedUser(Guid.NewGuid(), "anna", "session-token-1");
+
+        await _controller.Logout(CancellationToken.None);
+
+        await _users.Received(1).DeleteSession("session-token-1", Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ChangePassword_WeakPassword_Returns400()
+    {
+        SetAuthenticatedUser(Guid.NewGuid(), "anna", "tok");
+
+        var result = await _controller.ChangePassword(new ChangePasswordRequest { CurrentPassword = ValidPassword, NewPassword = "weak" }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task ChangePassword_WrongCurrent_Returns400()
+    {
+        var user = MakeUser("anna", ValidPassword);
+        _users.GetUserById(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        SetAuthenticatedUser(user.Id, "anna", "tok");
+
+        var result = await _controller.ChangePassword(new ChangePasswordRequest { CurrentPassword = "Wrong1!Currentxxx", NewPassword = "NewPassword1!xxxx" }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public void GetProvider_ReturnsLocalMetadata()
+    {
+        var result = _controller.GetProvider();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.IsNotNull(ok);
+        StringAssert.Contains("local", System.Text.Json.JsonSerializer.Serialize(ok!.Value));
+    }
+
+    [Test]
+    public void AnonymousEndpoints_AreMarkedAllowAnonymous()
+    {
+        foreach (var name in new[] { nameof(AuthController.Login), nameof(AuthController.Redeem), nameof(AuthController.GetProvider) })
+        {
+            var method = typeof(AuthController).GetMethod(name)!;
+            Assert.IsNotEmpty(method.GetCustomAttributes(typeof(AllowAnonymousAttribute), false), $"{name} should be [AllowAnonymous]");
+        }
+    }
+
+    [Test]
+    public void ChangePassword_RequiresRealUserPolicy()
+    {
+        var method = typeof(AuthController).GetMethod(nameof(AuthController.ChangePassword))!;
+        var attr = (AuthorizeAttribute)method.GetCustomAttributes(typeof(AuthorizeAttribute), false).Single();
+        Assert.AreEqual(AuthPolicies.RealUser, attr.Policy);
+    }
+}

--- a/src/Config.UnitTests/Controllers/UsersControllerTests.cs
+++ b/src/Config.UnitTests/Controllers/UsersControllerTests.cs
@@ -175,10 +175,18 @@ public class UsersControllerTests
     }
 
     [Test]
-    public void Controller_RequiresAdminPolicy()
+    public void EveryAdminAction_RequiresAdminPolicy()
     {
-        var attr = (AuthorizeAttribute)typeof(UsersController).GetCustomAttributes(typeof(AuthorizeAttribute), false).Single();
-        Assert.AreEqual(AuthPolicies.AdminOnly, attr.Policy);
+        // No controller-level policy (it would AND with the guest-only create
+        // endpoint and lock guest out) — so every other action must carry AdminOnly.
+        var actions = typeof(UsersController).GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.DeclaredOnly)
+            .Where(m => m.Name != nameof(UsersController.CreateFirstUser));
+        foreach (var method in actions)
+        {
+            var attr = method.GetCustomAttributes(typeof(AuthorizeAttribute), false).Cast<AuthorizeAttribute>().SingleOrDefault();
+            Assert.IsNotNull(attr, $"{method.Name} must carry an [Authorize] policy");
+            Assert.AreEqual(AuthPolicies.AdminOnly, attr!.Policy, $"{method.Name} must require AdminOnly");
+        }
     }
 
     [Test]

--- a/src/Config.UnitTests/Controllers/UsersControllerTests.cs
+++ b/src/Config.UnitTests/Controllers/UsersControllerTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using pote.Config.Admin.Api.Auth;
+using pote.Config.Admin.Api.Controllers;
+using pote.Config.Admin.Api.Model.RequestResponse;
+using pote.Config.DataProvider.Interfaces;
+using pote.Config.DbModel;
+
+namespace pote.Config.UnitTests.Controllers;
+
+[TestFixture]
+public class UsersControllerTests
+{
+    private IUserDataAccess _users = null!;
+    private UsersController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _users = Substitute.For<IUserDataAccess>();
+        var authService = new AuthService(_users, new PasswordHasher<User>(), new AuthSettings(),
+            Substitute.For<ILogger<AuthService>>());
+        _controller = new UsersController(Substitute.For<ILogger<UsersController>>(), _users, authService,
+            new AuthSettings(), Substitute.For<IAuditLogHandler>());
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, "admin1"),
+            new Claim(ClaimTypes.Role, UserRoles.Admin),
+            new Claim(AuthPolicies.UserIdClaim, Guid.NewGuid().ToString())
+        }, "test");
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        _controller.HttpContext.User = new ClaimsPrincipal(identity);
+    }
+
+    [Test]
+    public async Task CreateInvite_ValidRequest_ReturnsToken()
+    {
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await _controller.CreateInvite(new CreateInviteRequest { Username = "anna", Role = "User" }, CancellationToken.None);
+
+        var ok = result.Result as OkObjectResult;
+        Assert.IsNotNull(ok);
+        var token = (TokenResponse)ok!.Value!;
+        Assert.IsNotEmpty(token.Token);
+        await _users.Received(1).UpsertInvite(Arg.Is<UserInvite>(i => i.Username == "anna" && i.Role == "User" && i.CreatedBy == "admin1"), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task CreateInvite_ExistingUser_Returns400()
+    {
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(new User { Username = "anna" });
+
+        var result = await _controller.CreateInvite(new CreateInviteRequest { Username = "anna", Role = "User" }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result.Result);
+    }
+
+    [Test]
+    public async Task CreateInvite_SoftDeletedUser_Returns400WithRestoreHint()
+    {
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(new User { Username = "anna", Deleted = true });
+
+        var result = await _controller.CreateInvite(new CreateInviteRequest { Username = "anna", Role = "User" }, CancellationToken.None);
+
+        var bad = result.Result as BadRequestObjectResult;
+        Assert.IsNotNull(bad);
+        StringAssert.Contains("Restore", System.Text.Json.JsonSerializer.Serialize(bad!.Value));
+    }
+
+    [Test]
+    public async Task CreateInvite_GuestUsername_Returns400()
+    {
+        var result = await _controller.CreateInvite(new CreateInviteRequest { Username = "guest", Role = "User" }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result.Result);
+    }
+
+    [Test]
+    public async Task CreateInvite_InvalidRole_Returns400()
+    {
+        var result = await _controller.CreateInvite(new CreateInviteRequest { Username = "anna", Role = "Root" }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result.Result);
+    }
+
+    [Test]
+    public async Task Delete_Self_Returns400()
+    {
+        _users.GetUserByUsername("admin1", Arg.Any<CancellationToken>()).Returns(new User { Username = "admin1" });
+
+        var result = await _controller.Delete("admin1", permanent: false, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+        await _users.DidNotReceive().SoftDeleteUser(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Delete_LastAdmin_Returns400()
+    {
+        var user = new User { Username = "anna", Role = UserRoles.Admin };
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+        _users.SoftDeleteUser(user.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await _controller.Delete("anna", permanent: false, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Delete_Permanent_OnActiveUser_Returns400()
+    {
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(new User { Username = "anna", Deleted = false });
+
+        var result = await _controller.Delete("anna", permanent: true, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+        await _users.DidNotReceive().PermanentlyDeleteUser(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Delete_Permanent_OnDeletedUser_Deletes()
+    {
+        var user = new User { Username = "anna", Deleted = true };
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _controller.Delete("anna", permanent: true, CancellationToken.None);
+
+        Assert.IsInstanceOf<OkResult>(result);
+        await _users.Received(1).PermanentlyDeleteUser(user.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Restore_DeletedUser_Restores()
+    {
+        var user = new User { Username = "anna", Deleted = true };
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await _controller.Restore("anna", CancellationToken.None);
+
+        Assert.IsInstanceOf<OkResult>(result);
+        await _users.Received(1).RestoreUser(user.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ChangeRole_LastAdminDemotion_Returns400()
+    {
+        var user = new User { Username = "anna", Role = UserRoles.Admin };
+        _users.GetUserByUsername("anna", Arg.Any<CancellationToken>()).Returns(user);
+        _users.UpdateRole(user.Id, "User", Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await _controller.ChangeRole("anna", new ChangeRoleRequest { Role = "User" }, CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task CreateResetLink_ForGuest_Returns400()
+    {
+        _users.GetUserByUsername("guest", Arg.Any<CancellationToken>()).Returns(new User { Username = "guest", IsGuest = true });
+
+        var result = await _controller.CreateResetLink("guest", CancellationToken.None);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result.Result);
+    }
+
+    [Test]
+    public void Controller_RequiresAdminPolicy()
+    {
+        var attr = (AuthorizeAttribute)typeof(UsersController).GetCustomAttributes(typeof(AuthorizeAttribute), false).Single();
+        Assert.AreEqual(AuthPolicies.AdminOnly, attr.Policy);
+    }
+
+    [Test]
+    public void CreateFirstUser_RequiresGuestPolicy()
+    {
+        var method = typeof(UsersController).GetMethod(nameof(UsersController.CreateFirstUser))!;
+        var attr = (AuthorizeAttribute)method.GetCustomAttributes(typeof(AuthorizeAttribute), false).Single();
+        Assert.AreEqual(AuthPolicies.GuestOnly, attr.Policy);
+    }
+}

--- a/src/Config.UnitTests/File/AuditLogHandlerTests.cs
+++ b/src/Config.UnitTests/File/AuditLogHandlerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
@@ -22,25 +22,43 @@ public class AuditLogHandlerTests
     [Test]
     public async Task AuditLogConfiguration_FormatsAndDelegates()
     {
-        await _sut.AuditLogConfiguration("id1", "192.168.1.1", "config content");
+        await _sut.AuditLogConfiguration("id1", "192.168.1.1", "tester", "Insert", "config content");
 
         await _fileHandler.Received(1).AuditLogConfiguration("id1",
             Arg.Is<string>(s => s.Contains("192.168.1.1") && s.Contains("config content")));
     }
 
     [Test]
-    public async Task AuditLogConfiguration_IncludesNewlineBetweenIpAndContent()
+    public async Task AuditLogConfiguration_IncludesNewlineBetweenHeaderAndContent()
     {
-        await _sut.AuditLogConfiguration("id1", "10.0.0.1", "payload");
+        await _sut.AuditLogConfiguration("id1", "10.0.0.1", "tester", "Insert", "payload");
 
         await _fileHandler.Received(1).AuditLogConfiguration("id1",
-            Arg.Is<string>(s => s.Contains("10.0.0.1" + Environment.NewLine + "payload")));
+            Arg.Is<string>(s => s.Contains("10.0.0.1 tester Insert" + Environment.NewLine + "payload")));
+    }
+
+    [Test]
+    public async Task AuditLogConfiguration_NullUsername_WritesDash()
+    {
+        await _sut.AuditLogConfiguration("id1", "10.0.0.1", null, "Insert", "payload");
+
+        await _fileHandler.Received(1).AuditLogConfiguration("id1",
+            Arg.Is<string>(s => s.Contains("10.0.0.1 - Insert")));
+    }
+
+    [Test]
+    public async Task AuditLogUser_DelegatesToSettingsAudit()
+    {
+        await _sut.AuditLogUser("00000000-0000-0000-0000-000000000001", "10.0.0.1", "admin1", "UserCreated", "anna");
+
+        await _fileHandler.Received(1).AuditLogSettings(
+            Arg.Is<string>(s => s.Contains("UserCreated") && s.Contains("anna") && s.Contains("admin1")));
     }
 
     [Test]
     public async Task AuditLogEnvironment_FormatsAndDelegates()
     {
-        await _sut.AuditLogEnvironment("env1", "10.0.0.1", "env content");
+        await _sut.AuditLogEnvironment("env1", "10.0.0.1", "tester", "Insert", "env content");
 
         await _fileHandler.Received(1).AuditLogEnvironment("env1",
             Arg.Is<string>(s => s.Contains("10.0.0.1") && s.Contains("env content")));
@@ -49,7 +67,7 @@ public class AuditLogHandlerTests
     [Test]
     public async Task AuditLogApplication_FormatsAndDelegates()
     {
-        await _sut.AuditLogApplication("app1", "10.0.0.1", "app content");
+        await _sut.AuditLogApplication("app1", "10.0.0.1", "tester", "Insert", "app content");
 
         await _fileHandler.Received(1).AuditLogApplication("app1",
             Arg.Is<string>(s => s.Contains("10.0.0.1") && s.Contains("app content")));
@@ -58,7 +76,7 @@ public class AuditLogHandlerTests
     [Test]
     public async Task AuditLogSettings_FormatsAndDelegates()
     {
-        await _sut.AuditLogSettings("settings1", "10.0.0.1", "settings content");
+        await _sut.AuditLogSettings("settings1", "10.0.0.1", "tester", "Save", "settings content");
 
         await _fileHandler.Received(1).AuditLogSettings(
             Arg.Is<string>(s => s.Contains("10.0.0.1") && s.Contains("settings content")));
@@ -67,7 +85,7 @@ public class AuditLogHandlerTests
     [Test]
     public async Task AuditLogApiKeys_FormatsAndDelegates()
     {
-        await _sut.AuditLogApiKeys("keys1", "10.0.0.1", "apikeys content");
+        await _sut.AuditLogApiKeys("keys1", "10.0.0.1", "tester", "Save", "apikeys content");
 
         await _fileHandler.Received(1).AuditLogApiKeys(
             Arg.Is<string>(s => s.Contains("10.0.0.1") && s.Contains("apikeys content")));
@@ -76,7 +94,7 @@ public class AuditLogHandlerTests
     [Test]
     public async Task AuditLogSecrets_FormatsAndDelegates()
     {
-        await _sut.AuditLogSecrets("sec1", "10.0.0.1", "secret content");
+        await _sut.AuditLogSecrets("sec1", "10.0.0.1", "tester", "Insert", "secret content");
 
         await _fileHandler.Received(1).AuditLogSecrets("sec1",
             Arg.Is<string>(s => s.Contains("10.0.0.1") && s.Contains("secret content")));

--- a/src/Config.UnitTests/SqlServer/InMemorySqlConnectionFactory.cs
+++ b/src/Config.UnitTests/SqlServer/InMemorySqlConnectionFactory.cs
@@ -132,6 +132,8 @@ public class InMemorySqlConnectionFactory : SqlConnectionFactory, IDisposable
                 [EntityId] TEXT NOT NULL,
                 [CallerIp] TEXT NOT NULL,
                 [Content] TEXT NOT NULL,
+                [Username] TEXT NULL,
+                [Action] TEXT NULL,
                 [CreatedUtc] TEXT NOT NULL DEFAULT (datetime('now'))
             );
 

--- a/src/Config.UnitTests/SqlServer/SqlServerAuditLogHandlerTests.cs
+++ b/src/Config.UnitTests/SqlServer/SqlServerAuditLogHandlerTests.cs
@@ -1,4 +1,4 @@
-using System.Data;
+﻿using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,7 +34,7 @@ public class SqlServerAuditLogHandlerTests
     [Test]
     public async Task AuditLogConfiguration_InsertsRow()
     {
-        await _sut.AuditLogConfiguration("cfg1", "10.0.0.1", "config content");
+        await _sut.AuditLogConfiguration("cfg1", "10.0.0.1", "tester", "Insert", "config content");
 
         var conn = await _factory.CreateOpenConnection();
         var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
@@ -42,12 +42,28 @@ public class SqlServerAuditLogHandlerTests
         Assert.AreEqual("cfg1", (string)row.EntityId);
         Assert.AreEqual("10.0.0.1", (string)row.CallerIp);
         Assert.AreEqual("config content", (string)row.Content);
+        Assert.AreEqual("tester", (string)row.Username);
+        Assert.AreEqual("Insert", (string)row.Action);
+    }
+
+    [Test]
+    public async Task AuditLogUser_InsertsRowWithUserEntityType()
+    {
+        await _sut.AuditLogUser("00000000-0000-0000-0000-000000000001", "10.0.0.9", "admin1", "UserCreated", "anna");
+
+        var conn = await _factory.CreateOpenConnection();
+        var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
+        Assert.AreEqual("User", (string)row.EntityType);
+        Assert.AreEqual("00000000-0000-0000-0000-000000000001", (string)row.EntityId);
+        Assert.AreEqual("admin1", (string)row.Username);
+        Assert.AreEqual("UserCreated", (string)row.Action);
+        Assert.AreEqual("anna", (string)row.Content);
     }
 
     [Test]
     public async Task AuditLogEnvironment_InsertsRow()
     {
-        await _sut.AuditLogEnvironment("env1", "10.0.0.2", "env content");
+        await _sut.AuditLogEnvironment("env1", "10.0.0.2", "tester", "Insert", "env content");
 
         var conn = await _factory.CreateOpenConnection();
         var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
@@ -58,7 +74,7 @@ public class SqlServerAuditLogHandlerTests
     [Test]
     public async Task AuditLogApplication_InsertsRow()
     {
-        await _sut.AuditLogApplication("app1", "10.0.0.3", "app content");
+        await _sut.AuditLogApplication("app1", "10.0.0.3", "tester", "Insert", "app content");
 
         var conn = await _factory.CreateOpenConnection();
         var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
@@ -69,7 +85,7 @@ public class SqlServerAuditLogHandlerTests
     [Test]
     public async Task AuditLogSettings_InsertsRow()
     {
-        await _sut.AuditLogSettings("s1", "10.0.0.4", "settings content");
+        await _sut.AuditLogSettings("s1", "10.0.0.4", "tester", "Save", "settings content");
 
         var conn = await _factory.CreateOpenConnection();
         var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
@@ -79,7 +95,7 @@ public class SqlServerAuditLogHandlerTests
     [Test]
     public async Task AuditLogApiKeys_InsertsRow()
     {
-        await _sut.AuditLogApiKeys("k1", "10.0.0.5", "apikeys content");
+        await _sut.AuditLogApiKeys("k1", "10.0.0.5", "tester", "Save", "apikeys content");
 
         var conn = await _factory.CreateOpenConnection();
         var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
@@ -89,7 +105,7 @@ public class SqlServerAuditLogHandlerTests
     [Test]
     public async Task AuditLogSecrets_InsertsRow()
     {
-        await _sut.AuditLogSecrets("sec1", "10.0.0.6", "secret content");
+        await _sut.AuditLogSecrets("sec1", "10.0.0.6", "tester", "Insert", "secret content");
 
         var conn = await _factory.CreateOpenConnection();
         var row = await conn.QueryFirstAsync("SELECT * FROM [AuditLog]");
@@ -100,8 +116,8 @@ public class SqlServerAuditLogHandlerTests
     [Test]
     public async Task MultipleAuditLogs_InsertMultipleRows()
     {
-        await _sut.AuditLogConfiguration("c1", "ip1", "content1");
-        await _sut.AuditLogEnvironment("e1", "ip2", "content2");
+        await _sut.AuditLogConfiguration("c1", "ip1", "u1", "Insert", "content1");
+        await _sut.AuditLogEnvironment("e1", "ip2", "u2", "Insert", "content2");
 
         var conn = await _factory.CreateOpenConnection();
         var count = await conn.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM [AuditLog]");


### PR DESCRIPTION
Adds user login to the admin page: database-backed authentication with revocable sessions, a guest bootstrap user, invite-only user creation, roles, and soft delete — architected so the identity provider is swappable later (OIDC/ADFS).

Spec: `docs/plans/2026-08-04-admin-login-design.md` (brainstormed, grilled, externally reviewed — triage in `2026-08-04-admin-login-spec-review.md`). ADRs 0002–0005.

## What's in it

**Backend (Admin API)**
- DB-backed sessions (opaque bearer tokens, `Sessions` table, 8 h absolute lifetime): revocable, restart-safe, load-balancer-safe, no signing keys (ADR-0003)
- Pluggable `IAuthProviderSetup` seam; app authorizes on claims only (`name`, `role`, `guest`) (ADR-0002)
- Guest bootstrap: empty `Users` table seeds `guest`/`guest`, which can only create the first admin and is hard-deleted on the first real login; empty store = disaster recovery (ADR-0004)
- Invite-only users with roles (`Admin`/`User`), admin-driven reset links (same redeem mechanism), change-password, soft delete + restore + explicit permanent delete, last-active-admin rail
- Rate-limited login/redeem, uniform 401s with dummy-hash timing, 16-char password policy, `Cache-Control: no-store` on token responses
- Audit log gains `Username` and `Action` columns; failed logins audited
- SQL scripts `15`–`18` (users/invites/resets/sessions with FKs, CI collation, CHECK constraints) + idempotent `19` audit-log alter
- SQL Server becomes the default provider; File provider throws `NotSupportedException` for user storage and the API fails fast on that combination (ADR-0005)
- `X-API-Key` removed from the Admin API (Config.Api untouched)

**Frontend (SvelteKit)**
- Login page, invite/reset redemption page (token in URL fragment, stripped immediately), guest-locked first-user screen, users admin page (invite with role, copyable links, revoke, role change, soft delete/restore/permanent delete, last-login), change-password + logout menu
- Session store in localStorage; `client.ts` sends bearer tokens and redirects to `/login` on 401; `apiKey` removed from `config.json`

**Tests**: 252 backend unit tests (75 new: auth service, policies, handlers, controllers), 58 frontend unit tests, 12 Playwright e2e (6 new auth flows). Full guest→first-admin→invite flow also verified manually against a real SQL Server.

## Breaking changes (release notes)

- Admin API requires login; scripts must call `POST api/auth/login` first
- Run `CreateScripts` `15`–`19` on existing databases
- Default `DataProvider` is now `SqlServer`
- Remove `apiKey` from the SPA's `config.json`
- After upgrade: log in as `guest`/`guest` and claim the instance immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
