### PR TITLE
Unsaved-changes guard on Applications, Environments and API keys

### DIFF
--- a/Tasks/done/20260805-105145-unsaved-changes-guard-list-pages.md
+++ b/Tasks/done/20260805-105145-unsaved-changes-guard-list-pages.md
@@ -1,0 +1,54 @@
+# Unsaved Changes Guard List Pages
+
+## Status
+done  <!-- todo | in progress | blocked | done -->
+
+Implemented 2026-08-05: guard extracted into
+`src/lib/components/UnsavedChangesGuard.svelte` and wired into
+`NameTablePage.svelte` (Applications + Environments) and
+`routes/ApiKeys/+page.svelte`. Covered by 6 new e2e tests in
+`e2e/smoke.spec.ts`. `HeaderEditorPage.svelte` still has its own inline copy of
+the guard — a candidate for adopting the shared component later, left alone here
+to avoid touching working code.
+
+## Task
+Extend the unsaved-changes navigation guard from the configuration editor to the
+Applications, Environments and API keys pages: when a row has been edited, added
+or marked deleted, in-app navigation must be interrupted with a confirm dialog
+asking whether to discard the changes.
+
+Done when: editing any row on those three pages and then clicking a nav link
+cancels the navigation and shows the "Unsaved changes" dialog; confirming leaves
+and discards, cancelling stays on the page with edits intact.
+
+## Notes
+Reference implementation: `src/Config.Admin.WebClient/src/lib/components/HeaderEditorPage.svelte`
+- Dirty tracking at line 51 via `createDirtyTracker` (`src/lib/dirty.svelte.ts`) —
+  generic over `T`, deep-equal against a baseline snapshot.
+- `beforeNavigate` guard at lines 272–281: `navigation.type === 'leave'` (tab
+  close) just cancels; in-app navigation stores `navigation.to.url`, cancels, and
+  opens the dialog. `confirmLeave` (283) sets a `bypassGuard` flag before `goto`
+  so the second navigation isn't re-intercepted.
+- Tab-close prompt via `<svelte:window onbeforeunload>` at lines 290–294.
+- Dialog: `ConfirmDialog` at lines 413–419, title "Unsaved changes".
+
+Two touch points cover all three pages:
+1. `src/lib/components/NameTablePage.svelte` — shared by both
+   `routes/applications/+page.svelte` and `routes/environments/+page.svelte`, so
+   one change covers both. Baseline should be snapshotted in `load()` (line 32),
+   which is also called after a successful `save()` — that resets the baseline
+   for free.
+2. `routes/ApiKeys/+page.svelte` — standalone page with its own `keys` state and
+   `load()`/`save()`; needs the guard wired up separately. Note its rows are
+   keyed by index and deletion splices the array rather than flagging
+   `isDeleted`, but snapshot-compare dirty tracking handles that unchanged.
+
+## Questions
+- ~~Should the Refresh button prompt for confirmation when dirty?~~
+  **Decided 2026-08-05: no.** The guard fires only on navigation. Refresh keeps
+  discarding edits silently as it does today (tooltip: "Load from server, will
+  undo changes").
+- ~~Should the tab-close/reload `onbeforeunload` prompt be included too?~~
+  **Included as implemented**, matching the config editor. Still not explicitly
+  confirmed — trivial to drop by removing the `<svelte:window>` block from
+  `UnsavedChangesGuard.svelte`.

--- a/src/Config.Admin.WebClient/e2e/smoke.spec.ts
+++ b/src/Config.Admin.WebClient/e2e/smoke.spec.ts
@@ -71,6 +71,41 @@ test('unsaved-changes guard blocks navigation until confirmed', async ({ page })
 	await expect(page).toHaveURL(/secrets/);
 });
 
+// Applications and Environments share NameTablePage; Api keys has its own page.
+for (const { title, url } of [
+	{ title: 'Applications', url: '/applications' },
+	{ title: 'Environments', url: '/environments' },
+	{ title: 'Api keys', url: '/ApiKeys' }
+]) {
+	test(`unsaved-changes guard blocks navigation away from ${title}`, async ({ page }) => {
+		await page.goto(url);
+		const firstName = page.getByPlaceholder('enter name').first();
+		await expect(firstName).toBeVisible();
+		await firstName.fill('Dirty value');
+
+		await page.getByRole('link', { name: 'Secrets' }).click();
+		await expect(page.getByText('You have unsaved changes')).toBeVisible();
+
+		// Stay: cancel keeps us on the page with the edit intact.
+		await page.getByRole('button', { name: 'Cancel' }).click();
+		await expect(page).toHaveURL(new RegExp(url, 'i'));
+		await expect(firstName).toHaveValue('Dirty value');
+
+		// Leave: confirm discards and navigates.
+		await page.getByRole('link', { name: 'Secrets' }).click();
+		await page.getByRole('button', { name: 'Leave' }).click();
+		await expect(page).toHaveURL(/secrets/);
+	});
+
+	test(`navigation away from ${title} is not blocked when unchanged`, async ({ page }) => {
+		await page.goto(url);
+		await expect(page.getByPlaceholder('enter name').first()).toBeVisible();
+		await page.getByRole('link', { name: 'Secrets' }).click();
+		await expect(page).toHaveURL(/secrets/);
+		await expect(page.getByText('You have unsaved changes')).toBeHidden();
+	});
+}
+
 test('boot fails with a clear page when config.json is missing', async ({ page }) => {
 	await page.route('**/config.json', (route) => route.fulfill({ status: 404, body: 'not found' }));
 	await page.goto('/');

--- a/src/Config.Admin.WebClient/src/lib/components/NameTablePage.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/NameTablePage.svelte
@@ -4,7 +4,9 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Table from '$lib/components/ui/table';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import UnsavedChangesGuard from '$lib/components/UnsavedChangesGuard.svelte';
 	import UsagesPanel from '$lib/components/UsagesPanel.svelte';
+	import { createDirtyTracker } from '$lib/dirty.svelte';
 	import { clearPageError, setPageError } from '$lib/stores/pageError.svelte';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
@@ -29,11 +31,18 @@
 
 	let rows = $state<Row[]>([]);
 
+	// The baseline is re-snapshotted on every load, which includes the reload
+	// after a successful save — so saving also clears the dirty state.
+	const tracker = createDirtyTracker(() => $state.snapshot(rows));
+	const isDirty = $derived(tracker.isDirty);
+
 	async function load() {
 		clearPageError();
 		const result = await fetchAll();
-		if (result.ok) rows = result.value.toSorted((a, b) => a.name.localeCompare(b.name));
-		else setPageError(result.error.message);
+		if (result.ok) {
+			rows = result.value.toSorted((a, b) => a.name.localeCompare(b.name));
+			tracker.reset($state.snapshot(rows));
+		} else setPageError(result.error.message);
 	}
 	const loading = load();
 
@@ -51,6 +60,8 @@
 		toast.success(`${title} saved`);
 	}
 </script>
+
+<UnsavedChangesGuard isDirty={() => isDirty} />
 
 <div class="mb-4 flex items-center gap-2">
 	<h1 class="mr-4 text-xl font-semibold">{title}</h1>

--- a/src/Config.Admin.WebClient/src/lib/components/UnsavedChangesGuard.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/UnsavedChangesGuard.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { beforeNavigate, goto } from '$app/navigation';
+	import ConfirmDialog from './dialogs/ConfirmDialog.svelte';
+
+	// isDirty is a getter, not a value, so the guard always sees the caller's
+	// current state rather than a snapshot taken at mount.
+	let { isDirty }: { isDirty: () => boolean } = $props();
+
+	let leaveOpen = $state(false);
+	let leaveTarget: URL | null = null;
+	let bypassGuard = false;
+
+	// Unsaved-changes guard: in-app navigation gets a dialog, tab close the
+	// browser prompt.
+	beforeNavigate((navigation) => {
+		if (!isDirty() || bypassGuard) return;
+		if (navigation.type === 'leave') {
+			navigation.cancel();
+			return;
+		}
+		leaveTarget = navigation.to?.url ?? null;
+		navigation.cancel();
+		leaveOpen = true;
+	});
+
+	function confirmLeave() {
+		if (!leaveTarget) return;
+		bypassGuard = true;
+		goto(leaveTarget).finally(() => (bypassGuard = false));
+	}
+</script>
+
+<svelte:window
+	onbeforeunload={(e) => {
+		if (isDirty()) e.preventDefault();
+	}}
+/>
+
+<ConfirmDialog
+	bind:open={leaveOpen}
+	title="Unsaved changes"
+	message="You have unsaved changes. Leave the page and lose them?"
+	confirmLabel="Leave"
+	onConfirm={confirmLeave}
+/>

--- a/src/Config.Admin.WebClient/src/routes/ApiKeys/+page.svelte
+++ b/src/Config.Admin.WebClient/src/routes/ApiKeys/+page.svelte
@@ -5,6 +5,8 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Table from '$lib/components/ui/table';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import UnsavedChangesGuard from '$lib/components/UnsavedChangesGuard.svelte';
+	import { createDirtyTracker } from '$lib/dirty.svelte';
 	import { clearPageError, setPageError } from '$lib/stores/pageError.svelte';
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import KeyRoundIcon from '@lucide/svelte/icons/key-round';
@@ -17,11 +19,18 @@
 	type KeyRow = { name: string; key: string };
 	let keys = $state<KeyRow[]>([]);
 
+	// The baseline is re-snapshotted on every load, which includes the reload
+	// after a successful save — so saving also clears the dirty state.
+	const tracker = createDirtyTracker(() => $state.snapshot(keys));
+	const isDirty = $derived(tracker.isDirty);
+
 	async function load() {
 		clearPageError();
 		const result = await getApiKeys();
-		if (result.ok) keys = (result.value.apiKeys?.keys ?? []).map((k) => ({ name: k.name ?? '', key: k.key ?? '' }));
-		else setPageError(result.error.message);
+		if (result.ok) {
+			keys = (result.value.apiKeys?.keys ?? []).map((k) => ({ name: k.name ?? '', key: k.key ?? '' }));
+			tracker.reset($state.snapshot(keys));
+		} else setPageError(result.error.message);
 	}
 	const loading = load();
 
@@ -47,6 +56,8 @@
 </script>
 
 <svelte:head><title>Api keys</title></svelte:head>
+
+<UnsavedChangesGuard isDirty={() => isDirty} />
 
 <div class="mb-4 flex items-center gap-2">
 	<h1 class="mr-4 text-xl font-semibold">API Keys</h1>


### PR DESCRIPTION
## What

Editing a configuration and navigating away interrupts the page switch and asks whether to discard the changes. This extends the same behaviour to **Applications**, **Environments** and **API keys**.

The config editor's guard is extracted into a reusable `UnsavedChangesGuard` component that owns the `beforeNavigate` hook, the confirm dialog and the tab-close prompt, so it's one line per page instead of three copies of ~20 lines:

- `NameTablePage.svelte` — covers both Applications and Environments, since they share it
- `routes/ApiKeys/+page.svelte` — its own page, wired separately

Dirty state reuses the existing `createDirtyTracker`, with the baseline re-snapshotted in `load()`. Because `load()` also runs after a successful save, saving clears the dirty state for free.

## Decisions

- **The guard only fires on navigation.** The Refresh button still discards edits silently, as it does today (its tooltip already says "Load from server, will undo changes").
- **The tab-close/reload prompt is included**, matching the config editor. Easy to drop by removing the `<svelte:window>` block from `UnsavedChangesGuard.svelte`.
- **`HeaderEditorPage.svelte` is left alone.** It keeps its own inline copy of the guard — it also uses `bypassGuard` for its save/delete flows, so adopting the shared component there is a separate change rather than a risk taken here.

## Testing

- `npm run check` — 0 errors (2 warnings, both pre-existing in untouched files)
- `npm test` — 58 passed
- `npm run test:e2e` — 18 passed, including 6 new tests: per page, a dirty edit blocks navigation with the dialog, Cancel keeps you on the page with the edit intact, Leave discards and navigates; plus the negative case that an unchanged page navigates freely

Note: Playwright's browser binaries weren't present locally, so the e2e suite couldn't run at all until Chromium was installed — worth knowing if CI has never exercised these tests.

## Also included

A `Tasks/` folder holding the docket entry for this work, marked done. This is the first task file in the repo, so it establishes the convention (`Tasks/` for open, `Tasks/done/` for completed). Happy to drop it from the PR if you'd rather keep that out of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)