### PR TITLE
Move the add-row button into the toolbar

### DIFF
--- a/Tasks/done/20260805-112924-move-add-button-to-toolbar.md
+++ b/Tasks/done/20260805-112924-move-add-button-to-toolbar.md
@@ -1,0 +1,35 @@
+# Move Add Button To Toolbar
+
+## Status
+done  <!-- todo | in progress | blocked | done -->
+
+Implemented 2026-08-05: add button moved into the toolbar after Save on both
+`NameTablePage.svelte` and `routes/ApiKeys/+page.svelte`, wrapped in a tooltip to
+match Refresh/Save. Trailing header cells kept but emptied. Covered by 3 new e2e
+tests in `e2e/smoke.spec.ts`.
+
+## Task
+On the Applications, Environments and API keys pages the "+" add-row button sits
+in the last column of the table header. Move it up into the top toolbar next to
+the Refresh and Save icons.
+
+Done when: each of the three pages shows the "+" in the toolbar row beside
+Refresh/Save, adding a row still works, and the table header no longer carries an
+add button.
+
+## Notes
+- `src/lib/components/NameTablePage.svelte` — shared by Applications and
+  Environments. Add button at lines 96–105 (inside `<Table.Head class="w-8">`),
+  toolbar at lines 66–88. `aria-label="Add"`.
+- `src/routes/ApiKeys/+page.svelte` — add button at lines 94–98, toolbar at
+  lines 62–84. `aria-label="Add key"`.
+- The trailing `<Table.Head class="w-8">` cells stay (body rows still hold the
+  delete / copy / generate buttons); they just become empty, which the API keys
+  page already does for two of its columns.
+- Toolbar buttons are wrapped in `Tooltip.Root`; the add button currently has no
+  tooltip, so wrap it to match its new neighbours. Keep the existing aria-labels
+  unchanged so a11y and any selectors keep working.
+
+## Questions
+- Placement within the toolbar: assumed after Save (the arrow in the request
+  screenshot points at the space just right of the save icon).

--- a/src/Config.Admin.WebClient/e2e/smoke.spec.ts
+++ b/src/Config.Admin.WebClient/e2e/smoke.spec.ts
@@ -72,10 +72,10 @@ test('unsaved-changes guard blocks navigation until confirmed', async ({ page })
 });
 
 // Applications and Environments share NameTablePage; Api keys has its own page.
-for (const { title, url } of [
-	{ title: 'Applications', url: '/applications' },
-	{ title: 'Environments', url: '/environments' },
-	{ title: 'Api keys', url: '/ApiKeys' }
+for (const { title, url, addLabel } of [
+	{ title: 'Applications', url: '/applications', addLabel: 'Add' },
+	{ title: 'Environments', url: '/environments', addLabel: 'Add' },
+	{ title: 'Api keys', url: '/ApiKeys', addLabel: 'Add key' }
 ]) {
 	test(`unsaved-changes guard blocks navigation away from ${title}`, async ({ page }) => {
 		await page.goto(url);
@@ -103,6 +103,23 @@ for (const { title, url } of [
 		await page.getByRole('link', { name: 'Secrets' }).click();
 		await expect(page).toHaveURL(/secrets/);
 		await expect(page.getByText('You have unsaved changes')).toBeHidden();
+	});
+
+	test(`${title} add button sits in the toolbar and appends a row`, async ({ page }) => {
+		await page.goto(url);
+		const names = page.getByPlaceholder('enter name');
+		await expect(names.first()).toBeVisible();
+		const before = await names.count();
+
+		// The add button belongs to the toolbar next to Refresh/Save, not the
+		// table header.
+		const addButton = page.getByRole('button', { name: addLabel, exact: true });
+		await expect(addButton).toBeVisible();
+		await expect(page.locator('thead button')).toHaveCount(0);
+
+		await addButton.click();
+		await expect(names).toHaveCount(before + 1);
+		await expect(names.last()).toHaveValue('');
 	});
 }
 

--- a/src/Config.Admin.WebClient/src/lib/components/NameTablePage.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/NameTablePage.svelte
@@ -85,6 +85,22 @@
 		</Tooltip.Trigger>
 		<Tooltip.Content>Save changes</Tooltip.Content>
 	</Tooltip.Root>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Button
+					{...props}
+					variant="ghost"
+					size="icon"
+					onclick={() => rows.push({ id: crypto.randomUUID(), name: '', isDeleted: false })}
+					aria-label="Add"
+				>
+					<PlusIcon class="size-4 text-success" />
+				</Button>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>Add a row</Tooltip.Content>
+	</Tooltip.Root>
 </div>
 
 {#await loading then}
@@ -93,16 +109,7 @@
 			<Table.Row>
 				<Table.Head class="w-72">Name</Table.Head>
 				<Table.Head>Usages</Table.Head>
-				<Table.Head class="w-8">
-					<Button
-						variant="ghost"
-						size="icon"
-						onclick={() => rows.push({ id: crypto.randomUUID(), name: '', isDeleted: false })}
-						aria-label="Add"
-					>
-						<PlusIcon class="size-4 text-success" />
-					</Button>
-				</Table.Head>
+				<Table.Head class="w-8"></Table.Head>
 			</Table.Row>
 		</Table.Header>
 		<Table.Body>

--- a/src/Config.Admin.WebClient/src/routes/ApiKeys/+page.svelte
+++ b/src/Config.Admin.WebClient/src/routes/ApiKeys/+page.svelte
@@ -81,6 +81,22 @@
 		</Tooltip.Trigger>
 		<Tooltip.Content>Save changes</Tooltip.Content>
 	</Tooltip.Root>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Button
+					{...props}
+					variant="ghost"
+					size="icon"
+					onclick={() => keys.push({ name: '', key: generateApiKey() })}
+					aria-label="Add key"
+				>
+					<PlusIcon class="size-4 text-success" />
+				</Button>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>Add a key</Tooltip.Content>
+	</Tooltip.Root>
 </div>
 
 {#await loading then}
@@ -91,11 +107,7 @@
 				<Table.Head>Key</Table.Head>
 				<Table.Head class="w-8"></Table.Head>
 				<Table.Head class="w-8"></Table.Head>
-				<Table.Head class="w-8">
-					<Button variant="ghost" size="icon" onclick={() => keys.push({ name: '', key: generateApiKey() })} aria-label="Add key">
-						<PlusIcon class="size-4 text-success" />
-					</Button>
-				</Table.Head>
+				<Table.Head class="w-8"></Table.Head>
 			</Table.Row>
 		</Table.Header>
 		<Table.Body>


### PR DESCRIPTION
## What

On **Applications**, **Environments** and **API keys** the `+` add-row button was tucked into the last cell of the table header. It now sits in the top toolbar after Save.


- `NameTablePage.svelte` — covers Applications and Environments
- `routes/ApiKeys/+page.svelte`

The trailing `<Table.Head class="w-8">` cells stay but are now empty, since body rows still hold the delete / copy / generate buttons. The API keys page already had two empty header cells, so this matches.

## Judgment calls

- **Placement after Save**, per the arrow in the request screenshot pointing just right of the save icon.
- **Wrapped in a tooltip** ("Add a row" / "Add a key") because every other toolbar button has one; the button previously had only an `aria-label`. The aria-labels are unchanged (`Add`, `Add key`), so selectors and screen-reader output stay the same.

## Testing

- `npm run check` — 0 errors (2 warnings, both pre-existing in untouched files)
- `npm test` — 58 passed
- `npm run test:e2e` — **21 passed**, including 3 new tests (one per page) asserting the add button is reachable, that `thead` contains no buttons at all, and that clicking it appends an empty row

Also verified by hand in the browser on Applications and API keys: button renders in the toolbar, header is empty, and adding still appends a row — with a generated key on the API keys page.
