### PR TITLE
Constrain select dropdown height so long lists scroll

### DIFF
--- a/src/Config.Admin.WebClient/src/lib/components/ui/select/select-content.svelte
+++ b/src/Config.Admin.WebClient/src/lib/components/ui/select/select-content.svelte
@@ -27,7 +27,7 @@
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			"min-w-36 rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 relative isolate z-50 overflow-x-hidden overflow-y-auto",
+			"min-w-36 rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 relative isolate z-50 flex max-h-(--bits-floating-available-height) flex-col overflow-hidden",
 			className
 		)}
 		{...restProps}
@@ -35,7 +35,7 @@
 		<SelectScrollUpButton />
 		<SelectPrimitive.Viewport
 			class={cn(
-				"h-(--bits-select-anchor-height) w-full min-w-(--bits-select-anchor-width) scroll-my-1"
+				"min-h-0 w-full min-w-(--bits-floating-anchor-width) scroll-my-1 overflow-y-auto overscroll-contain"
 			)}
 		>
 			{@render children?.()}


### PR DESCRIPTION
## What

The multi-select popovers in the section editor (Environments / Applications) grew to the full height of their item list, ran off the bottom of the window, and had no scrollbar — so with 40+ applications the lower entries could not be selected at all.

`select-content.svelte` set `overflow-y-auto` but never constrained the height. It also referenced `--bits-select-anchor-height` / `--bits-select-anchor-width`, which the installed bits-ui (2.18) does not emit — it sets generic `--bits-floating-*` vars on the floating wrapper, so those two declarations were invalid and silently dropped.

## How

- **Content** — `max-h-(--bits-floating-available-height)` plus `flex flex-col overflow-hidden`. That variable is what floating-ui's `size` middleware measured as the room to the window edge for the chosen side, so it stays correct when the popover flips above the trigger.
- **Viewport** — becomes the scroller (`min-h-0 … overflow-y-auto overscroll-contain`). This is deliberate: it's the node bits-ui's `ScrollUpButton`/`ScrollDownButton` read (`viewportNode.scrollHeight/clientHeight`), so putting the overflow on the content instead would give a native scrollbar but leave those chevrons permanently hidden.
- Fixed `min-w-(--bits-floating-anchor-width)` to the var name that actually exists.

## Verification

The Admin API wasn't running, so the real editor page was unreachable. Verified against a throwaway probe route instead — a 40-item multi-select at a 900x700 viewport — then deleted it.

| | before | after |
|---|---|---|
| content height | unbounded | 648px = measured available height |
| content bottom edge | past the window | 700px, exactly the window edge |
| viewport scrollable | no | yes (scrollHeight 1148 vs client 624) |

Scrolled to the bottom and confirmed the last item sits fully inside the window, with bits-ui's scroll-down chevron mounted alongside the native scrollbar. `npm run check` passes: 0 errors, 2 pre-existing warnings in unrelated files.

## For the reviewer

`dropdown-menu-content.svelte` has the identical two defects (no max-height, and `w-(--bits-dropdown-menu-anchor-width)` is likewise a var bits-ui never sets). Left out of this PR because every menu using it today — theme, user, nav — is short enough that it never shows. Happy to fold it in if you'd rather fix both at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
